### PR TITLE
Refactor visualization functions

### DIFF
--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -1,23 +1,46 @@
 using Graphs: SimpleGraph, Edge, nv
-using GraphMakie: graphplot!, GraphPlot
+using GraphMakie: graphplot!, GraphPlot, to_colormap, get_node_plot
 using Combinatorics: combinations
+using GraphMakie.NetworkLayout: IterativeLayout
 import Makie
 
-Makie.plottype(::TensorNetwork) = GraphPlot
+const MAX_NODE_SIZE = 20.
 
-function Makie.plot!(P::GraphPlot{Tuple{TensorNetwork{A}}}; kwargs...) where {A<:Ansatz}
-    tn = P[1][]
+function Makie.plot(tn::TensorNetwork{A}; kwargs...) where {A<:Ansatz}
+    f = Makie.Figure()
+
+    p, ax = Makie.plot!(f[1,1], tn; kwargs...)
+    display(f)
+
+    return f, ax, p
+end
+
+function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; kwargs...) where {A<:Ansatz}
+    scene = Makie.Scene()
+    default_attrs = Makie.default_theme(scene, GraphPlot)
+
+    kwargs = Dict{Symbol,Any}(kwargs)
 
     pos = IdDict(tensor => i for (i, tensor) in enumerate(tensors(tn)))
     graph = SimpleGraph([Edge(pos[a], pos[b]) for ind in inds(tn) for (a, b) in combinations(links(ind), 2)])
 
-    scene = Makie.parent_scene(P)
-    default_attrs = Makie.default_theme(scene, GraphPlot)
+    log_size = [log2(size(tensors(tn, i)) |> prod) for i in 1:nv(graph)]
 
-    kwargs = Dict{Symbol,Any}(kwargs)
-    if P.attributes.node_size[] == default_attrs.node_size[]
-        kwargs[:node_size] = [max(10, log2(size(tensors(tn, i)) |> prod)) for i in 1:nv(graph)]
+    min_size, max_size = extrema(log_size)
+
+    kwargs[:node_size] = (log_size/max_size) * MAX_NODE_SIZE
+
+    if haskey(kwargs, :layout) && kwargs[:layout] isa IterativeLayout{3}
+        ax = Makie.LScene(f[1,1])
+    else
+        ax = Makie.Axis(f[1,1])
+        # hide decorations if it is not a 3D plot
+        Makie.hidedecorations!(ax)
+        Makie.hidespines!(ax)
+        ax.aspect = DataAspect()
     end
 
-    graphplot!(P, graph; kwargs...)
+    p = graphplot!(f[1,1], graph; kwargs...)
+
+    return p, ax
 end

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -24,11 +24,7 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; kwargs...) whe
     pos = IdDict(tensor => i for (i, tensor) in enumerate(tensors(tn)))
     graph = SimpleGraph([Edge(pos[a], pos[b]) for ind in inds(tn) for (a, b) in combinations(links(ind), 2)])
 
-    log_size = [log2(size(tensors(tn, i)) |> prod) for i in 1:nv(graph)]
-
-    min_size, max_size = extrema(log_size)
-
-    kwargs[:node_size] = (log_size/max_size) * MAX_NODE_SIZE
+    kwargs[:node_size] = [max(10, log2(size(tensors(tn,i)) |> prod)) for i in 1:nv(graph)]
 
     if haskey(kwargs, :layout) && kwargs[:layout] isa IterativeLayout{3}
         ax = Makie.LScene(f[1,1])

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -31,7 +31,7 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; kwargs...) whe
         # hide decorations if it is not a 3D plot
         Makie.hidedecorations!(ax)
         Makie.hidespines!(ax)
-        ax.aspect = DataAspect()
+        ax.aspect = Makie.DataAspect()
     end
 
     p = graphplot!(f[1,1], graph; kwargs...)

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -4,8 +4,6 @@ using Combinatorics: combinations
 using GraphMakie.NetworkLayout: IterativeLayout
 import Makie
 
-const MAX_NODE_SIZE = 20.
-
 function Makie.plot(tn::TensorNetwork{A}; kwargs...) where {A<:Ansatz}
     f = Makie.Figure()
 


### PR DESCRIPTION
Plot recipes currently describe plot primitives that live in an `Axis` but can not change the `Axis` parameters. Therefore, with plot recipes, we can't currently include `Colorbar`s, add interactions, and in general, customize the `Axis`.
In this PL we address #5, and we change the plot function so now it can take a `GridPosition` and plot into it. This enabled us to add the following features:

- Added integration to plot the contraction paths into subplots.
- Added the possibility to create 3D plots.

### Example:
```julia
julia> using Tenet
julia> using Makie
julia> using GLMakie
julia> tn = rand(TensorNetwork, 60, 3)
TensorNetwork{Arbitrary}(#tensors=60, #inds=90)
julia> f = Figure(backgroundcolor="ivory", resolution=(1000, 700))
julia> scatter(f[1,1], 1..4, log)
Makie.AxisPlot(Axis (1 plots), Scatter{Tuple{Vector{Point{2, Float32}}}})
julia> lines(f[2,1], 1..10, cos)
Makie.AxisPlot(Axis (1 plots), Lines{Tuple{Vector{Point{2, Float32}}}})
julia> using NetworkLayout
julia> plot!(f[1:2,2], tn; layout=Spring(dim=3))
(Combined{GraphMakie.graphplot, Tuple{Graphs.SimpleGraphs.SimpleGraph{Int64}}}, LScene())
```
![image](https://user-images.githubusercontent.com/61060572/217881002-c8ec6f9b-1416-4497-ad95-00319030972c.png)
