### PR TITLE
Add `labels` keyword argument into plot functions

### DIFF
--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -23,7 +23,7 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
     graph = SimpleGraph([Edge(pos[a], pos[b]) for ind in inds(tn) for (a, b) in combinations(links(ind), 2)])
 
     kwargs[:node_size] = [max(10, log2(size(tensors(tn,i)) |> prod)) for i in 1:nv(graph)]
-    elabels = [join(tn.tensors[edge.src].labels ∩ tn.tensors[edge.dst].labels) for edge in edges(graph)]
+    elabels = [join(labels(tensors(tn)[edge.src]) ∩ labels(tensors(tn)[edge.dst]), delim=',') for edge in edges(graph)]
 
     if haskey(kwargs, :layout) && kwargs[:layout] isa IterativeLayout{3}
         ax = Makie.LScene(f[1,1])

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -23,7 +23,7 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
     graph = SimpleGraph([Edge(pos[a], pos[b]) for ind in inds(tn) for (a, b) in combinations(links(ind), 2)])
 
     kwargs[:node_size] = [max(10, log2(size(tensors(tn,i)) |> prod)) for i in 1:nv(graph)]
-    elabels = [join(labels(tensors(tn)[edge.src]) ∩ labels(tensors(tn)[edge.dst]), delim=',') for edge in edges(graph)]
+    elabels = [join(labels(tensors(tn)[edge.src]) ∩ labels(tensors(tn)[edge.dst]), ',') for edge in edges(graph)]
 
     if haskey(kwargs, :layout) && kwargs[:layout] isa IterativeLayout{3}
         ax = Makie.LScene(f[1,1])


### PR DESCRIPTION
### Summary
We add `labels` as a keyword argument into both `plot` and `plot!` functions. This argument is `false` by default, but if it's `true`, the plot displays the index label of each edge.

### Example
```julia
julia> using Tenet
julia> using CairoMakie
julia> using Makie
julia> tn = rand(TensorNetwork, 10, 3)
TensorNetwork{Arbitrary}(#tensors=10, #inds=15)
julia> plot(tn; labels=true)
(Scene (800px, 600px):
  0 Plots
  1 Child Scene:
    └ Scene (800px, 600px), Axis (1 plots), Combined{GraphMakie.graphplot, Tuple{Graphs.SimpleGraphs.SimpleGraph{Int64}}})
julia> [tensor.labels for tensor in tn.tensors]
10-element Vector{Tuple{Symbol, Vararg{Symbol}}}:
 (:m, :d, :j)
 (:k, :i, :o)
 (:c, :f, :d)
 (:l, :c, :f)
 (:a, :m, :n, :j, :g, :o)
 (:h,)
 (:k, :b, :i)
 (:a, :e)
 (:e, :l)
 (:h, :g, :b, :n)
```
![image](https://user-images.githubusercontent.com/61060572/220408497-f521e36f-734f-4126-bdb7-b85fb03a0dbe.png)
