### PR TITLE
Fix from last PR: bug in plot functions

### DIFF
--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -23,7 +23,7 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
     graph = SimpleGraph([Edge(pos[a], pos[b]) for ind in inds(tn) for (a, b) in combinations(links(ind), 2)])
 
     kwargs[:node_size] = [max(10, log2(size(tensors(tn,i)) |> prod)) for i in 1:nv(graph)]
-    elabels = [join(labels(tensors(tn)[edge.src]) ∩ labels(tensors(tn)[edge.dst]), ',') for edge in edges(graph)]
+    elabels = [join(Tenet.labels(tensors(tn)[edge.src]) ∩ Tenet.labels(tensors(tn)[edge.dst]), ',') for edge in edges(graph)]
 
     if haskey(kwargs, :layout) && kwargs[:layout] isa IterativeLayout{3}
         ax = Makie.LScene(f[1,1])


### PR DESCRIPTION
Small fix from last PR, the plot function crashed since the function `labels` conflicts with the keyword argument `labels`. 