### PR TITLE
Fix crash in `transform` function: `transformations` argument

### DIFF
--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -4,14 +4,14 @@ abstract type Transformation end
 
 function transform! end
 
-function transform!(tn::TensorNetwork, transformations::Sequence{Transformation})
+function transform!(tn::TensorNetwork, transformations::Sequence{A}) where {A<:Transformation}
     for transformation in transformations
-        transform!(tn, transformation)
+        transform!(tn, typeof(transformation))
     end
     return tn
 end
 
-function transform(tn::TensorNetwork, transformations::Sequence{Transformation})
+function transform(tn::TensorNetwork, transformations::Sequence{A}) where {A<:Transformation}
     tn = copy(tn)
     transform!(tn, transformations)
     return tn

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -4,14 +4,14 @@ abstract type Transformation end
 
 function transform! end
 
-function transform!(tn::TensorNetwork, transformations::Sequence{A}) where {A<:Transformation}
+function transform!(tn::TensorNetwork, transformations::Sequence{Transformation})
     for transformation in transformations
-        transform!(tn, typeof(transformation))
+        transform!(tn, transformation)
     end
     return tn
 end
 
-function transform(tn::TensorNetwork, transformations::Sequence{A}) where {A<:Transformation}
+function transform(tn::TensorNetwork, transformations::Sequence{Transformation})
     tn = copy(tn)
     transform!(tn, transformations)
     return tn

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -2,18 +2,16 @@ using DeltaArrays
 
 abstract type Transformation end
 
+transform(tn::TensorNetwork, transformations) = (tn = copy(tn); transform!(tn, transformations); return tn)
+
 function transform! end
 
-function transform!(tn::TensorNetwork, transformations::Sequence{Transformation})
+transform!(tn::TensorNetwork, transformation::Type{<:Transformation}) = transform!(tn, transformation())
+
+function transform!(tn::TensorNetwork, transformations::Sequence)
     for transformation in transformations
         transform!(tn, transformation)
     end
-    return tn
-end
-
-function transform(tn::TensorNetwork, transformations::Sequence{Transformation})
-    tn = copy(tn)
-    transform!(tn, transformations)
     return tn
 end
 
@@ -22,7 +20,7 @@ struct HyperindConverter <: Transformation end
 """
     Converts hyperindices to COPY tensors.
 """
-function transform!(tn::TensorNetwork, ::Type{HyperindConverter})
+function transform!(tn::TensorNetwork, ::HyperindConverter)
     for index in hyperinds(tn)
         # unlink index
         tensors = [pop!(tn, tensor) for tensor in links(index)]

--- a/test/Transformations_test.jl
+++ b/test/Transformations_test.jl
@@ -1,5 +1,21 @@
 @testset "Transformations" begin
-    using Tenet: transform!
+    using Tenet: transform, transform!, Transformation
+
+    @testset "transform" begin
+        struct MockTransformation <: Transformation end
+        Tenet.transform!(::TensorNetwork, ::MockTransformation) = nothing
+
+        tn = rand(TensorNetwork, 10, 3)
+        @test isnothing(transform!(tn, MockTransformation()))
+        @test isnothing(transform!(tn, MockTransformation))
+        @test transform!(tn, [MockTransformation]) === tn
+        @test transform!(tn, [MockTransformation()]) === tn
+
+        @test transform(tn, MockTransformation) isa TensorNetwork
+        @test transform(tn, MockTransformation()) isa TensorNetwork
+        @test transform(tn, [MockTransformation]) isa TensorNetwork
+        @test transform(tn, [MockTransformation()]) isa TensorNetwork
+    end
 
     @testset "HyperindConverter" begin
         using Tenet: HyperindConverter


### PR DESCRIPTION
### Summary
This PR addresses the bug found in the `transform` function. This bug was not found before because this function is not included in the tests at the moment.
Previously, we could not call the `transform` function since the `transformations` argument accepted the type `Sequence{Transformation}` and `Transformation` is an abstract type. This is now changed so it accepts a `Sequence` of `struct`s that inherit from `Transformation`.

### Example
```julia
julia> using Tenet
julia> tn = TensorNetwork([Tensor(rand([2, 2, 2]...), tuple([:i, :j, :k]...)), Tensor(rand([2, 2, 2]...), tuple([:i, :k, :l]...)), Tensor(rand([2, 2, 2]...), tuple([:i, :l, :j]...))])
TensorNetwork{Arbitrary}(#tensors=3, #inds=4)
julia> tn = transform(tn, [Tenet.HyperindConverter()])
TensorNetwork{Arbitrary}(#tensors=4, #inds=6)
```
Although this may be counter-intuitive since the `transform!` function is called with:
```julia
julia> transform!(tn, Tenet.HyperindConverter)
```
What do you think, @mofeing ?