### PR TITLE
Fix plots for `TensorNetworks` with hyperedges

### DIFF
--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -24,7 +24,8 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
     pos = IdDict(tensor => i for (i, tensor) in enumerate(tensors(tn)))
     graph = SimpleGraph([Edge(pos[a], pos[b]) for ind in inds(tn) for (a, b) in combinations(links(ind), 2)])
 
-    copytensors = findall(Base.Fix2((x,y) -> haskey(x.meta, y), :dual), tensors(tn))
+    # TODO recognise them by using `DeltaArray` or `Diagonal` representations
+    copytensors = findall(t -> haskey(t.meta, :dual), tensors(tn))
 
     kwargs[:node_size] = [max(15, log2(size(tensors(tn,i)) |> prod)) for i in 1:nv(graph)]
     kwargs[:node_marker] = [i ∈ copytensors ? :diamond : :circle for i in 1:length(tensors(tn))]

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -17,13 +17,37 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
     scene = Makie.Scene()
     default_attrs = Makie.default_theme(scene, GraphPlot)
 
+    transform!(tn, HyperindConverter)
+
     kwargs = Dict{Symbol,Any}(kwargs)
 
     pos = IdDict(tensor => i for (i, tensor) in enumerate(tensors(tn)))
     graph = SimpleGraph([Edge(pos[a], pos[b]) for ind in inds(tn) for (a, b) in combinations(links(ind), 2)])
 
-    kwargs[:node_size] = [max(10, log2(size(tensors(tn,i)) |> prod)) for i in 1:nv(graph)]
-    elabels = [join(Tenet.labels(tensors(tn)[edge.src]) ∩ Tenet.labels(tensors(tn)[edge.dst]), ',') for edge in edges(graph)]
+    copytensors = findall(Base.Fix2((x,y) -> haskey(x.meta, y), :dual), tensors(tn))
+
+    kwargs[:node_size] = [max(15, log2(size(tensors(tn,i)) |> prod)) for i in 1:nv(graph)]
+    kwargs[:node_marker] = [i ∈ copytensors ? :diamond : :circle for i in 1:length(tensors(tn))]
+    kwargs[:node_color] = [i ∈ copytensors ? :grey : :black for i in 1:length(tensors(tn))]
+
+    if labels
+        elabels = Vector{String}([])
+        edge_color = Vector{Symbol}([])
+
+        for edge in edges(graph)
+            copies = filter((x -> x ∈ copytensors), [edge.src, edge.dst])
+
+            if isempty(copies) # there are no copy tensors in the nodes of this edge
+                push!(elabels, join(Tenet.labels(tensors(tn)[edge.src]) ∩ Tenet.labels(tensors(tn)[edge.dst]), ','))
+                push!(edge_color, :black)
+            else
+                push!(elabels, string(tensors(tn)[copies[]].meta[:dual]))
+                push!(edge_color, :grey)
+            end
+        end
+
+        kwargs[:edge_color] = edge_color
+    end
 
     if haskey(kwargs, :layout) && kwargs[:layout] isa IterativeLayout{3}
         ax = Makie.LScene(f[1,1])

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -28,12 +28,11 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
 
     kwargs[:node_size] = [max(15, log2(size(tensors(tn,i)) |> prod)) for i in 1:nv(graph)]
     kwargs[:node_marker] = [i ∈ copytensors ? :diamond : :circle for i in 1:length(tensors(tn))]
-    kwargs[:node_color] = [i ∈ copytensors ? :grey : :black for i in 1:length(tensors(tn))]
+    kwargs[:node_color] = [i ∈ copytensors ? :black : :white for i in 1:length(tensors(tn))]
 
     if labels
         elabels = Vector{String}([])
         elabels_color = Vector{Symbol}([])
-        edge_color = Vector{Symbol}([])
 
         for edge in edges(graph)
             copies = filter((x -> x ∈ copytensors), [edge.src, edge.dst])
@@ -41,15 +40,11 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
             if isempty(copies) # there are no copy tensors in the nodes of this edge
                 push!(elabels, join(Tenet.labels(tensors(tn)[edge.src]) ∩ Tenet.labels(tensors(tn)[edge.dst]), ','))
                 push!(elabels_color, :black)
-                push!(edge_color, :black)
             else
                 push!(elabels, string(tensors(tn)[copies[]].meta[:dual]))
                 push!(elabels_color, :grey)
-                push!(edge_color, :grey)
             end
         end
-
-        kwargs[:edge_color] = edge_color
     end
 
     if haskey(kwargs, :layout) && kwargs[:layout] isa IterativeLayout{3}
@@ -64,9 +59,9 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
 
     p = graphplot!(f[1,1], graph;
         elabels = labels ? elabels : nothing,
-        elabels_color = labels ? elabels_color : [:black for i in 1:ne(graph)],
         # TODO configurable `elabels_textsize`
         elabels_textsize = [17 for i in 1:ne(graph)],
+        node_attr=(colormap = :viridis, strokewidth = 2., strokecolor = :black),
         kwargs...)
 
     return p, ax

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -17,7 +17,7 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
     scene = Makie.Scene()
     default_attrs = Makie.default_theme(scene, GraphPlot)
 
-    transform!(tn, HyperindConverter)
+    tn = transform(tn, HyperindConverter)
 
     kwargs = Dict{Symbol,Any}(kwargs)
 
@@ -32,6 +32,7 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
 
     if labels
         elabels = Vector{String}([])
+        elabels_color = Vector{Symbol}([])
         edge_color = Vector{Symbol}([])
 
         for edge in edges(graph)
@@ -39,9 +40,11 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
 
             if isempty(copies) # there are no copy tensors in the nodes of this edge
                 push!(elabels, join(Tenet.labels(tensors(tn)[edge.src]) ∩ Tenet.labels(tensors(tn)[edge.dst]), ','))
+                push!(elabels_color, :black)
                 push!(edge_color, :black)
             else
                 push!(elabels, string(tensors(tn)[copies[]].meta[:dual]))
+                push!(elabels_color, :grey)
                 push!(edge_color, :grey)
             end
         end
@@ -61,7 +64,7 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
 
     p = graphplot!(f[1,1], graph;
         elabels = labels ? elabels : nothing,
-        elabels_color = [:black for i in 1:ne(graph)],
+        elabels_color = labels ? elabels_color : [:black for i in 1:ne(graph)],
         # TODO configurable `elabels_textsize`
         elabels_textsize = [17 for i in 1:ne(graph)],
         kwargs...)


### PR DESCRIPTION
From issue #21 

### Summary
In this PR we fix the `plot` functions: now these can plot `TensorNetworks` with hyperedges. The hyperedges are visualized with a grey diamond-shaped COPY tensor, with grey indices coming from it.

### Example
```julia
julia> using Tenet
julia> using GLMakie
julia> using Makie
julia> tn = TensorNetwork([Tensor(rand([2, 2, 2]...), tuple([:i, :c, :k]...)), Tensor(rand([2, 2, 2, 2]...), tuple([:i, :k, :s, :p]...)), Tensor(rand([2, 2, 2]...), tuple([:i, :s, :c]...)), Tensor(rand([2, 2]...), tuple([:p, :t]...))])
TensorNetwork{Arbitrary}(#tensors=4, #inds=6)
julia> plot(tn; labels=true)
(Scene (800px, 600px):
  0 Plots
  1 Child Scene:
    └ Scene (800px, 600px), Axis (1 plots), Combined{GraphMakie.graphplot, Tuple{Graphs.SimpleGraphs.SimpleGraph{Int64}}})
julia> [tensor.labels for tensor in tn.tensors]
4-element Vector{Tuple{Symbol, Symbol, Vararg{Symbol}}}:
 (:i, :c, :k)
 (:i, :k, :s, :p)
 (:i, :s, :c)
 (:p, :t)
```
![Screenshot from 2023-02-23 16-51-13](https://user-images.githubusercontent.com/61060572/220959517-ef1c48d1-320b-4fd4-95df-321910d6b2a3.png)
