### PR TITLE
Add support for visualization of open indices in plot functions

### DIFF
--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -1,5 +1,5 @@
-using Graphs: SimpleGraph, Edge, edges, ne, nv
-using GraphMakie: graphplot!, GraphPlot, to_colormap, get_node_plot, add_edge!, add_vertex!
+using Graphs: SimpleGraph, Edge, edges, ne, nv, add_edge!, add_vertex!
+using GraphMakie: graphplot!, GraphPlot, to_colormap, get_node_plot
 using Combinatorics: combinations
 using GraphMakie.NetworkLayout: IterativeLayout
 import Makie

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -28,7 +28,7 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
     # TODO recognise them by using `DeltaArray` or `Diagonal` representations
     copytensors = findall(t -> haskey(t.meta, :dual), tensors(tn))
 
-    opentensors = findall(t-> !isempty(Tenet.labels(t) ∩ (i -> nameof(i)).(openinds(tn))), tensors(tn))
+    opentensors = findall(t-> !isempty(Tenet.labels(t) ∩ nameof.(openinds(tn))), tensors(tn))
 
     opencounter = IdDict(tensor => 1 for tensor in opentensors)
     ghostnodes = map(openinds(tn)) do ind

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -28,7 +28,7 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
     # TODO recognise them by using `DeltaArray` or `Diagonal` representations
     copytensors = findall(t -> haskey(t.meta, :dual), tensors(tn))
 
-    opentensors = findall(t-> !isempty(labels(t) ∩ openinds(tn)), tensors(tn))
+    opentensors = findall(t-> !isempty(Tenet.labels(t) ∩ (i -> nameof(i)).(openinds(tn))), tensors(tn))
 
     opencounter = IdDict(tensor => 1 for tensor in opentensors)
     ghostnodes = map(openinds(tn)) do ind
@@ -61,7 +61,7 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
                     push!(elabels_color, :grey)
                 end
             else
-                tensor_oinds = filter(id -> nameof(id) ∈ labels(tensors(tn)[only(notghosts)]), openinds(tn))
+                tensor_oinds = filter(id -> nameof(id) ∈ Tenet.labels(tensors(tn)[only(notghosts)]), openinds(tn))
                 indices = nameof.(tensor_oinds)
 
                 push!(elabels, string(indices[opencounter[only(notghosts)]]))

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -59,8 +59,8 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
                     push!(elabels_color, :grey)
                 end
             else
-                tensor_oinds = filter(id -> id.name ∈ tensors(tn)[notghosts[1]].labels, openinds(tn))
-                indices = (id -> id.name).(tensor_oinds)
+                tensor_oinds = filter(id -> nameof(id) ∈ tensors(tn)[only(notghosts)].labels, openinds(tn))
+                indices = (id -> nameof(id)).(tensor_oinds)
 
                 push!(elabels, join(indices, ","))
                 push!(elabels_color, :black)

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -48,8 +48,8 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
         elabels_color = Vector{Symbol}([])
 
         for edge in edges(graph)
-            copies = filter((x -> x ∈ copytensors), [edge.src, edge.dst])
-            notghosts = filter((x -> x ∉ ghostnodes), [edge.src, edge.dst])
+            copies = filter(x -> x ∈ copytensors, [edge.src, edge.dst])
+            notghosts = filter(x -> x ∉ ghostnodes, [edge.src, edge.dst])
 
             # TODO refactor this code
             if length(notghosts) == 2 # there are no ghost nodes in this edge

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -28,13 +28,14 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
     # TODO recognise them by using `DeltaArray` or `Diagonal` representations
     copytensors = findall(t -> haskey(t.meta, :dual), tensors(tn))
 
+    opentensors = findall(t -> any(s -> s ∈ (o -> nameof(o)).(openinds(tn)), t.labels), tensors(tn))
+
+    opencounter = Dict(tensor => 1 for tensor in opentensors)
     ghostnodes = map(openinds(tn)) do ind
         add_vertex!(graph)
-
         node = nv(graph) # TODO is this the best way to get the id of the newly created node?
         tensor = only(links(ind))
         add_edge!(graph, node, pos[tensor])
-
         return node
     end
 
@@ -62,8 +63,9 @@ function Makie.plot!(f::Makie.GridPosition, tn::TensorNetwork{A}; labels = false
                 tensor_oinds = filter(id -> nameof(id) ∈ tensors(tn)[only(notghosts)].labels, openinds(tn))
                 indices = (id -> nameof(id)).(tensor_oinds)
 
-                push!(elabels, join(indices, ","))
+                push!(elabels, string(indices[opencounter[only(notghosts)]]))
                 push!(elabels_color, :black)
+                opencounter[only(notghosts)] += 1
             end
         end
     end


### PR DESCRIPTION
### Summary
In this PR we address issue #32: we fix the plot functions so now we can visualize the open indices that a `TensorNetwork` may have. This is done by adding 'ghost' tensors of size zero at the edge of each open index.

### Example
```julia
julia> using Tenet
julia> using GLMakie; using Makie
julia> tn = TensorNetwork([Tensor(rand([2, 2, 2, 2, 2]...), tuple([:i, :t, :k, :x, :y]...)), Tensor(rand([2, 2, 2, 2]...), tuple([:i, :k, :s, :p]...)), Tensor(rand([2, 2]...), tuple([:i, :s]...)), Tensor(rand([2, 2, 2]...), tuple([:p, :t, :z]...))])
TensorNetwork{Arbitrary}(#tensors=4, #inds=8)
julia> using NetworkLayout
julia> plot(tn; labels=true, layout=Spring(dim=3))
Tuple{Symbol, Vararg{Symbol}}[(:p, :t, :z), (:i1, :t, :k, :x, :y), (:i2, :k, :s, :p), (:i3, :s), (:i1, :i2, :i3), (:y, :x), (:z,)]
julia> [tensor.labels for tensor in tn.tensors]
4-element Vector{Tuple{Symbol, Symbol, Vararg{Symbol}}}:
 (:i, :t, :k, :x, :y)
 (:i, :k, :s, :p)
 (:i, :s)
 (:p, :t, :z)
julia> openinds(tn)
3-element Vector{Index}:
 :y
 :z
 :x
```
![image](https://user-images.githubusercontent.com/61060572/222668502-5d0437a2-e2ff-48fe-ae81-1f07d1893362.png)
