### PR TITLE
Fix label permutation on `MatrixProductState`

### DIFF
--- a/src/MatrixProductState.jl
+++ b/src/MatrixProductState.jl
@@ -49,7 +49,7 @@ function MatrixProductState{Open}(arrays; χ = nothing, order = (:l, :r, :p), me
         rind = vinds[(i, mod1(i + 1, n))]
 
         labels = [lind, rind, pinds[i]]
-        permute!(labels, permutator)
+        invpermute!(labels, permutator)
 
         tensor = Tensor(data, labels)
         push!(tn, tensor)
@@ -88,7 +88,7 @@ function MatrixProductState{Closed}(arrays; χ = nothing, order = (:l, :r, :p), 
         rind = vinds[(i, mod1(i + 1, n))]
 
         labels = [lind, rind, pinds[i]]
-        permute!(labels, permutator)
+        invpermute!(labels, permutator)
 
         tensor = Tensor(data, labels)
         push!(tn, tensor)

--- a/test/MatrixProductState_test.jl
+++ b/test/MatrixProductState_test.jl
@@ -35,6 +35,12 @@
                 MatrixProductState{Open}(arrays) isa TensorNetwork{MatrixProductState{Open}}
             end
 
+            # custom order
+            @test begin
+                arrays = [rand(3, 1), rand(3, 1, 3), rand(1, 3)]
+                MatrixProductState{Open}(arrays, order = (:r, :p, :l)) isa TensorNetwork{MatrixProductState{Open}}
+            end
+
             # alternative constructor
             @test begin
                 arrays = [rand(1, 2), rand(1, 1, 2), rand(1, 2)]
@@ -59,6 +65,12 @@
             @test begin
                 arrays = [rand(3, 4, 2), rand(4, 8, 2), rand(8, 3, 2)]
                 MatrixProductState{Closed}(arrays) isa TensorNetwork{MatrixProductState{Closed}}
+            end
+
+            # custom order
+            @test begin
+                arrays = [rand(3, 1, 3), rand(3, 1, 3), rand(3, 1, 3)]
+                MatrixProductState{Closed}(arrays, order = (:r, :p, :l)) isa TensorNetwork{MatrixProductState{Closed}}
             end
 
             # alternative constructor


### PR DESCRIPTION
### Summary
In `MatrixProductState`, we first have the labels sorted in `(:l, :r, :i, :o)` and then we want to have it in `order`, but the permutator permutes from `order` to `(:l, :r, :i, :o)`, so instead of `permute!` we need `invpermute!`. This didn't fail in tests because in the case we considered the permutation was the same as the inverse permutation.

### Example
This code failed without this PR, and now works properly.
```julia
julia> using Tenet; using Test
julia> @test begin
           arrays = [rand(3, 1), rand(3, 1, 3), rand(1, 3)]
           MatrixProductState{Open}(arrays, order = (:r, :p, :l)) isa TensorNetwork{MatrixProductState{Open}}
       end
Test Passed
```
