### PR TITLE
Add `Base.replace!` function for `Tensor`s in a `TensorNetwork`

### DIFF
--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -45,12 +45,11 @@ function TensorNetwork{A}(tensors; meta...) where {A}
     return tn
 end
 
-function Base.replace!(tn::TensorNetwork, mapping::Pair{Tensor, Tensor})
-    index = findfirst(x -> x == old_tensor, tn.tensors)
-    old_labels = labels(old_tensor)
-    new_labels = labels(new_tensor)
+function Base.replace!(tn::TensorNetwork, mapping::Pair{<:Tensor, <:Tensor})
+    old_labels = labels(mapping[2])
+    new_labels = labels(mapping[1])
 
-    # check old and new tensors are compatible
+    # check if old and new tensors are compatible
     if !issetequal(new_labels, old_labels)
         throw(ArgumentError("New tensor labels do not match the existing tensor labels"))
     end
@@ -59,13 +58,13 @@ function Base.replace!(tn::TensorNetwork, mapping::Pair{Tensor, Tensor})
     # TODO remove this part when `Index` is removed
     for old_label in old_labels
         index_obj = tn.inds[old_label]
-        link_index = findfirst(x -> x === old_tensor, index_obj.links)
-        index_obj.links[link_index] = new_tensor
+        link_index = findfirst(x -> x === mapping[2], index_obj.links)
+        index_obj.links[link_index] = mapping[1]
     end
 
     # replace existing `Tensor` with new `Tensor`
-    index = findfirst(x -> x === old_tensor, tn.tensors)
-    tn.tensors[index] = new_tensor
+    index = findfirst(x -> x === mapping[2], tn.tensors)
+    tn.tensors[index] = mapping[1]
 
     return tn
 end

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -45,24 +45,26 @@ function TensorNetwork{A}(tensors; meta...) where {A}
     return tn
 end
 
-function Base.replace!(tn::TensorNetwork, old_tensor::Tensor, new_tensor::Tensor)
+function Base.replace!(tn::TensorNetwork, mapping::Pair{Tensor, Tensor})
     index = findfirst(x -> x == old_tensor, tn.tensors)
     old_labels = labels(old_tensor)
     new_labels = labels(new_tensor)
 
-    # Check if the new tensor is compatible with the existing
+    # check old and new tensors are compatible
     if !issetequal(new_labels, old_labels)
         throw(ArgumentError("New tensor labels do not match the existing tensor labels"))
     end
 
-    # Update tn.inds
+    # update index links
+    # TODO remove this part when `Index` is removed
     for old_label in old_labels
         index_obj = tn.inds[old_label]
         link_index = findfirst(x -> x === old_tensor, index_obj.links)
         index_obj.links[link_index] = new_tensor
     end
 
-    # Replace the existing Tensor with the new Tensor
+    # replace existing `Tensor` with new `Tensor`
+    index = findfirst(x -> x === old_tensor, tn.tensors)
     tn.tensors[index] = new_tensor
 
     return tn

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -45,7 +45,7 @@ function TensorNetwork{A}(tensors; meta...) where {A}
     return tn
 end
 
-function Base.replace!(tn::TensorNetwork, pair::Pair{Tensor, Tensor})
+function Base.replace!(tn::TensorNetwork, pair::Pair{<:Tensor, <:Tensor})
     old_tensor, new_tensor = pair
 
     # check if old and new tensors are compatible

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -45,26 +45,25 @@ function TensorNetwork{A}(tensors; meta...) where {A}
     return tn
 end
 
-function Base.replace!(tn::TensorNetwork, mapping::Pair{<:Tensor, <:Tensor})
-    old_labels = labels(mapping[2])
-    new_labels = labels(mapping[1])
+function Base.replace!(tn::TensorNetwork, pair::Pair{Tensor, Tensor})
+    old_tensor, new_tensor = pair
 
     # check if old and new tensors are compatible
-    if !issetequal(new_labels, old_labels)
+    if !issetequal(labels(new_tensor), labels(old_tensor))
         throw(ArgumentError("New tensor labels do not match the existing tensor labels"))
     end
 
     # update index links
     # TODO remove this part when `Index` is removed
-    for old_label in old_labels
+    for old_label in labels(old_tensor)
         index_obj = tn.inds[old_label]
-        link_index = findfirst(x -> x === mapping[2], index_obj.links)
-        index_obj.links[link_index] = mapping[1]
+        link_index = findfirst(x -> x === old_tensor, index_obj.links)
+        index_obj.links[link_index] = new_tensor
     end
 
     # replace existing `Tensor` with new `Tensor`
-    index = findfirst(x -> x === mapping[2], tn.tensors)
-    tn.tensors[index] = mapping[1]
+    index = findfirst(x -> x === old_tensor, tn.tensors)
+    tn.tensors[index] = new_tensor
 
     return tn
 end

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -45,6 +45,29 @@ function TensorNetwork{A}(tensors; meta...) where {A}
     return tn
 end
 
+function Base.replace!(tn::TensorNetwork, old_tensor::Tensor, new_tensor::Tensor)
+    index = findfirst(x -> x == old_tensor, tn.tensors)
+    old_labels = labels(old_tensor)
+    new_labels = labels(new_tensor)
+
+    # Check if the new tensor is compatible with the existing
+    if !issetequal(new_labels, old_labels)
+        throw(ArgumentError("New tensor labels do not match the existing tensor labels"))
+    end
+
+    # Update tn.inds
+    for old_label in old_labels
+        index_obj = tn.inds[old_label]
+        link_index = findfirst(x -> x === old_tensor, index_obj.links)
+        index_obj.links[link_index] = new_tensor
+    end
+
+    # Replace the existing Tensor with the new Tensor
+    tn.tensors[index] = new_tensor
+
+    return tn
+end
+
 # TODO checks? index metadata?
 TensorNetwork{A}(tn::TensorNetwork{B}) where {A,B} = TensorNetwork{B}(tensors(tn); tn.meta...)
 

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -233,12 +233,12 @@
 
             @test_throws ArgumentError begin
                 new_tensor = Tensor(rand(2, 2), (:a, :b))
-                replace!(tn, new_tensor => old_tensor)
+                replace!(tn, old_tensor => new_tensor)
             end
 
             new_tensor = Tensor(rand(2, 2), (:u, :w))
 
-            replace!(tn, new_tensor => old_tensor)
+            replace!(tn, old_tensor => new_tensor)
             @test new_tensor === tensors(tn, 2)
 
             # Check if connections are maintained
@@ -251,17 +251,17 @@
             # New tensor network with two tensors with the same labels
             A = Tensor(rand(2, 2), (:u, :w))
             B = Tensor(rand(2, 2), (:u, :w))
-            tn_2 = TensorNetwork([A, B])
+            tn = TensorNetwork([A, B])
 
             new_tensor = Tensor(rand(2, 2), (:u, :w))
 
-            replace!(tn_2, new_tensor => B)
-            @test A === tensors(tn_2, 1)
-            @test new_tensor === tensors(tn_2, 2)
+            replace!(tn, B => new_tensor)
+            @test A === tensors(tn, 1)
+            @test new_tensor === tensors(tn, 2)
 
-            tn_2 = TensorNetwork([A, B])
-            replace!(tn_2, new_tensor => A)
-            @test new_tensor === tensors(tn_2, 1)
+            tn = TensorNetwork([A, B])
+            replace!(tn, A => new_tensor)
+            @test new_tensor === tensors(tn, 1)
             @test B === tensors(tn_2, 2)
         end
     end

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -262,7 +262,7 @@
             tn = TensorNetwork([A, B])
             replace!(tn, A => new_tensor)
             @test new_tensor === tensors(tn, 1)
-            @test B === tensors(tn_2, 2)
+            @test B === tensors(tn, 2)
         end
     end
 end

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -233,12 +233,12 @@
 
             @test_throws ArgumentError begin
                 new_tensor = Tensor(rand(2, 2), (:a, :b))
-                replace!(tn, old_tensor, new_tensor)
+                replace!(tn, new_tensor => old_tensor)
             end
 
             new_tensor = Tensor(rand(2, 2), (:u, :w))
 
-            replace!(tn, old_tensor, new_tensor)
+            replace!(tn, new_tensor => old_tensor)
             @test new_tensor === tensors(tn, 2)
 
             # Check if connections are maintained
@@ -255,12 +255,12 @@
 
             new_tensor = Tensor(rand(2, 2), (:u, :w))
 
-            replace!(tn_2, B, new_tensor)
+            replace!(tn_2, new_tensor => B)
             @test A === tensors(tn_2, 1)
             @test new_tensor === tensors(tn_2, 2)
 
             tn_2 = TensorNetwork([A, B])
-            replace!(tn_2, A, new_tensor)
+            replace!(tn_2, new_tensor => A)
             @test new_tensor === tensors(tn_2, 1)
             @test B === tensors(tn_2, 2)
         end

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -247,6 +247,17 @@
                 @test new_tensor in index.links
                 @test !(old_tensor in index.links)
             end
+
+            # New tensor network with two tensors with the same labels
+            A = Tensor(rand(2, 2), (:u, :v))
+            B = Tensor(rand(2, 2), (:u, :w))
+            tn_2 = TensorNetwork([A, B])
+
+            new_tensor = Tensor(rand(2, 2), (:u, :w))
+
+            replace!(tn_2, B, new_tensor)
+            @test A === tensors(tn_2, 1)
+            @test new_tensor === tensors(tn_2, 2)
         end
     end
 end

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -249,7 +249,7 @@
             end
 
             # New tensor network with two tensors with the same labels
-            A = Tensor(rand(2, 2), (:u, :v))
+            A = Tensor(rand(2, 2), (:u, :w))
             B = Tensor(rand(2, 2), (:u, :w))
             tn_2 = TensorNetwork([A, B])
 
@@ -258,6 +258,11 @@
             replace!(tn_2, B, new_tensor)
             @test A === tensors(tn_2, 1)
             @test new_tensor === tensors(tn_2, 2)
+
+            tn_2 = TensorNetwork([A, B])
+            replace!(tn_2, A, new_tensor)
+            @test new_tensor === tensors(tn_2, 1)
+            @test B === tensors(tn_2, 2)
         end
     end
 end


### PR DESCRIPTION
This PR introduces a new `Base.replace!` function for the `TensorNetwork` type (issue #48). The function allows users to replace an existing `Tensor` within a `TensorNetwork`  with a new `Tensor`, provided that the new `Tensor` has `labels` that are a permutation of the old `Tensor`'s `labels`.

The implementation ensures that the `TensorNetwork`'s `inds` field is properly updated to maintain consistency within the network.

Example:
```julia
julia> using Tenet; using Test

julia> ψ = rand(MatrixProductState{Open}, 16, 2, 8) # Create a random tensor network
TensorNetwork{MatrixProductState{Open}}(#tensors=16, #inds=31)

julia> old_tensor = tensors(ψ, 2) # Retrieve a tensor from the network
2×4×2 Tensor{Float64, 3, Array{Float64, 3}}:
[:, :, 1] =
 0.429373   0.473947  0.475461   0.0111029
 0.165485  -0.148758  0.0920096  0.794718

[:, :, 2] =
 0.120982    0.506526   0.29635    0.0761409
 0.0279856  -0.149644  -0.0713865  0.531198

julia> new_tensor = Tensor(rand(size(old_tensor)...), labels(old_tensor)) # Create a new tensor with permuted labels
2×4×2 Tensor{Float64, 3, Array{Float64, 3}}:
[:, :, 1] =
 0.230909  0.981709  0.891462  0.833955
 0.558508  0.269235  0.520971  0.1338

[:, :, 2] =
 0.430268  0.695382  0.454548  0.702221
 0.296282  0.457037  0.207451  0.647955

julia> replace!(ψ, old_tensor, new_tensor) # Replace the old tensor with the new tensor in the network
TensorNetwork{MatrixProductState{Open}}(#tensors=16, #inds=31)

julia> @test tensors(ψ, 2) == new_tensor # Verify that the old tensor has been replaced
Test Passed
```

This addition enhances the flexibility of the `TensorNetwork` type and allows users to perform in-place modifications of tensor networks more efficiently.