### PR TITLE
Enhance `Tensor` metadata with label `alias` mapping

### DIFF
--- a/src/Quantum/MatrixProductOperator.jl
+++ b/src/Quantum/MatrixProductOperator.jl
@@ -27,26 +27,29 @@ function MatrixProductOperator{Open}(arrays; χ = nothing, order = (:l, :r, :i, 
     vinds = Dict(x => Symbol(uuid4()) for x in partition(1:n, 2, 1))
     oinds = Dict(i => Symbol(uuid4()) for i in 1:n)
     iinds = Dict(i => Symbol(uuid4()) for i in 1:n)
-    permutator = [order[i] for i in (:l, :r, :i, :o)]
-    # add boundary tensors
-    # first
-    labels = invpermute!([vinds[(1, 2)], iinds[1], oinds[1]], normalizeperm!([order[:r], order[:i], order[:o]]))
-    push!(tn, Tensor(first(arrays), labels))
 
-    # last
-    labels = invpermute!([vinds[(n - 1, n)], iinds[n], oinds[n]], normalizeperm!([order[:l], order[:i], order[:o]]))
-    push!(tn, Tensor(last(arrays), labels))
+    for (i, data) in enumerate(arrays)
+        # Handle boundary cases and inner tensors separately
+        if i == 1
+            labels = [vinds[(1, 2)], iinds[1], oinds[1]]
+            original_order = [:r, :i, :o]
+        elseif i == n
+            labels = [vinds[(n - 1, n)], iinds[n], oinds[n]]
+            original_order = [:l, :i, :o]
+        else
+            lind = vinds[(i - 1, i)]
+            rind = vinds[(i, i + 1)]
+            labels = [lind, rind, iinds[i], oinds[i]]
+            original_order = [:l, :r, :i, :o]
+        end
 
-    # add other tensors
-    for (i, data) in zip(2:n-1, arrays[2:end-1])
-        lind = vinds[(i - 1, i)]
-        rind = vinds[(i, i + 1)]
+        # Filter the order dictionary based on the original_order and sort it following order
+        filtered_order = [p[1] for p in sort(filter(p -> p.first ∈ original_order, collect(order)), by = x -> x[2])]
+        permutator = (ind -> Dict(p => i for (i, p) in enumerate(filtered_order))[ind]).(original_order)
 
-        labels = [lind, rind, iinds[i], oinds[i]]
         invpermute!(labels, permutator)
-
-        tensor = Tensor(data, labels)
-        push!(tn, tensor)
+        alias = Dict([x => y for (x, y) in zip(invpermute!(original_order, permutator), labels)])
+        push!(tn, Tensor(data, labels; alias = alias))
     end
 
     # mark input indices
@@ -91,7 +94,9 @@ function MatrixProductOperator{Closed}(arrays; χ = nothing, order = (:l, :r, :i
 
         labels = [lind, rind, iinds[i], oinds[i]]
         invpermute!(labels, permutator)
-        tensor = Tensor(data, labels)
+        alias = Dict([x => y for (x, y) in zip(invpermute!([:l, :r, :i, :o], permutator), labels)])
+
+        tensor = Tensor(data, labels; alias = alias)
         push!(tn, tensor)
     end
 

--- a/test/MatrixProductOperator_test.jl
+++ b/test/MatrixProductOperator_test.jl
@@ -55,7 +55,7 @@
                 MatrixProductOperator{Open}(arrays) isa TensorNetwork{MatrixProductOperator{Open}}
             end
 
-            @testset "`Tensor.meta[:alias]`" begin
+            @testset "alias" begin
                 arrays = [rand(1, 2, 2), rand(1, 1, 2, 2), rand(1, 2, 2)]
                 ψ = MatrixProductOperator{Open}(arrays, order = (:l, :r, :i, :o))
 

--- a/test/MatrixProductOperator_test.jl
+++ b/test/MatrixProductOperator_test.jl
@@ -55,18 +55,20 @@
                 MatrixProductOperator{Open}(arrays) isa TensorNetwork{MatrixProductOperator{Open}}
             end
 
-            @testset "alias" begin
-                arrays = [rand(1, 2, 2), rand(1, 1, 2, 2), rand(1, 2, 2)]
-                ψ = MatrixProductOperator{Open}(arrays, order = (:l, :r, :i, :o))
+            @testset "Metadata" begin
+                @testset "alias" begin
+                    arrays = [rand(1, 2, 2), rand(1, 1, 2, 2), rand(1, 2, 2)]
+                    ψ = MatrixProductOperator{Open}(arrays, order = (:l, :r, :i, :o))
 
-                @test ψ.meta[:order] == Dict(:l => 1, :r => 2, :i => 3, :o => 4)
+                    @test ψ.meta[:order] == Dict(:l => 1, :r => 2, :i => 3, :o => 4)
 
-                @test issetequal(keys(tensors(ψ, 1).meta[:alias]), [:r, :i, :o])
-                @test issetequal(keys(tensors(ψ, 2).meta[:alias]), [:l, :r, :i, :o])
-                @test issetequal(keys(tensors(ψ, 3).meta[:alias]), [:l, :i, :o])
+                    @test issetequal(keys(tensors(ψ, 1).meta[:alias]), [:r, :i, :o])
+                    @test issetequal(keys(tensors(ψ, 2).meta[:alias]), [:l, :r, :i, :o])
+                    @test issetequal(keys(tensors(ψ, 3).meta[:alias]), [:l, :i, :o])
 
-                @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
-                @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
+                    @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
+                    @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
+                end
             end
         end
 
@@ -106,19 +108,21 @@
                 MatrixProductOperator{Closed}(arrays) isa TensorNetwork{MatrixProductOperator{Closed}}
             end
 
-            @testset "alias" begin
-                arrays = [rand(1, 1, 2, 2), rand(1, 1, 2, 2), rand(1, 1, 2, 2)]
-                ψ = MatrixProductOperator{Closed}(arrays, order = (:l, :r, :i, :o))
+            @testset "Metadata" begin
+                @testset "alias" begin
+                    arrays = [rand(1, 1, 2, 2), rand(1, 1, 2, 2), rand(1, 1, 2, 2)]
+                    ψ = MatrixProductOperator{Closed}(arrays, order = (:l, :r, :i, :o))
 
-                @test ψ.meta[:order] == Dict(:l => 1, :r => 2, :i => 3, :o => 4)
+                    @test ψ.meta[:order] == Dict(:l => 1, :r => 2, :i => 3, :o => 4)
 
-                @test issetequal(keys(tensors(ψ, 1).meta[:alias]), [:l, :r, :i, :o])
-                @test issetequal(keys(tensors(ψ, 2).meta[:alias]), [:l, :r, :i, :o])
-                @test issetequal(keys(tensors(ψ, 3).meta[:alias]), [:l, :r, :i, :o])
+                    @test issetequal(keys(tensors(ψ, 1).meta[:alias]), [:l, :r, :i, :o])
+                    @test issetequal(keys(tensors(ψ, 2).meta[:alias]), [:l, :r, :i, :o])
+                    @test issetequal(keys(tensors(ψ, 3).meta[:alias]), [:l, :r, :i, :o])
 
-                @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
-                @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
-                @test tensors(ψ, 3).meta[:alias][:r] === tensors(ψ, 1).meta[:alias][:l]
+                    @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
+                    @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
+                    @test tensors(ψ, 3).meta[:alias][:r] === tensors(ψ, 1).meta[:alias][:l]
+                end
             end
         end
     end

--- a/test/MatrixProductOperator_test.jl
+++ b/test/MatrixProductOperator_test.jl
@@ -54,6 +54,20 @@
                 arrays = [rand(1, 1, 2, 2), rand(1, 1, 2, 2), rand(1, 1, 2, 2)]
                 MatrixProductOperator{Open}(arrays) isa TensorNetwork{MatrixProductOperator{Open}}
             end
+
+            @testset "`Tensor.meta[:alias]`" begin
+                arrays = [rand(1, 2, 2), rand(1, 1, 2, 2), rand(1, 2, 2)]
+                ψ = MatrixProductOperator{Open}(arrays, order = (:l, :r, :i, :o))
+
+                @test ψ.meta[:order] == Dict(:l => 1, :r => 2, :i => 3, :o => 4)
+
+                @test issetequal(keys(tensors(ψ, 1).meta[:alias]), [:r, :i, :o])
+                @test issetequal(keys(tensors(ψ, 2).meta[:alias]), [:l, :r, :i, :o])
+                @test issetequal(keys(tensors(ψ, 3).meta[:alias]), [:l, :i, :o])
+
+                @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
+                @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
+            end
         end
 
         @testset "`Closed` boundary" begin
@@ -90,6 +104,21 @@
             @test_throws DimensionMismatch begin
                 arrays = [rand(1, 2, 2), rand(1, 1, 2, 2), rand(1, 2, 2)]
                 MatrixProductOperator{Closed}(arrays) isa TensorNetwork{MatrixProductOperator{Closed}}
+            end
+
+            @testset "`Tensor.meta[:alias]`" begin
+                arrays = [rand(1, 1, 2, 2), rand(1, 1, 2, 2), rand(1, 1, 2, 2)]
+                ψ = MatrixProductOperator{Closed}(arrays, order = (:l, :r, :i, :o))
+
+                @test ψ.meta[:order] == Dict(:l => 1, :r => 2, :i => 3, :o => 4)
+
+                @test issetequal(keys(tensors(ψ, 1).meta[:alias]), [:l, :r, :i, :o])
+                @test issetequal(keys(tensors(ψ, 2).meta[:alias]), [:l, :r, :i, :o])
+                @test issetequal(keys(tensors(ψ, 3).meta[:alias]), [:l, :r, :i, :o])
+
+                @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
+                @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
+                @test tensors(ψ, 3).meta[:alias][:r] === tensors(ψ, 1).meta[:alias][:l]
             end
         end
     end

--- a/test/MatrixProductOperator_test.jl
+++ b/test/MatrixProductOperator_test.jl
@@ -106,7 +106,7 @@
                 MatrixProductOperator{Closed}(arrays) isa TensorNetwork{MatrixProductOperator{Closed}}
             end
 
-            @testset "`Tensor.meta[:alias]`" begin
+            @testset "alias" begin
                 arrays = [rand(1, 1, 2, 2), rand(1, 1, 2, 2), rand(1, 1, 2, 2)]
                 ψ = MatrixProductOperator{Closed}(arrays, order = (:l, :r, :i, :o))
 

--- a/test/MatrixProductState_test.jl
+++ b/test/MatrixProductState_test.jl
@@ -52,6 +52,18 @@
                 arrays = [rand(1, 1, 2), rand(1, 1, 2), rand(1, 1, 2)]
                 MatrixProductState{Open}(arrays) isa TensorNetwork{MatrixProductState{Open}}
             end
+
+            @testset "`Tensor.meta[:alias]`" begin
+                arrays = [rand(2, 2), rand(2, 2, 2), rand(2, 2)]
+                ψ = MatrixProductState{Open}(arrays, order = (:l, :p, :r))
+
+                @test issetequal(keys(tensors(ψ, 1).meta[:alias]), [:r, :p])
+                @test issetequal(keys(tensors(ψ, 2).meta[:alias]), [:l, :r, :p])
+                @test issetequal(keys(tensors(ψ, 3).meta[:alias]), [:l, :p])
+
+                @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
+                @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
+            end
         end
 
         @testset "`Closed` boundary" begin

--- a/test/MatrixProductState_test.jl
+++ b/test/MatrixProductState_test.jl
@@ -55,18 +55,20 @@
                 MatrixProductState{Open}(arrays) isa TensorNetwork{MatrixProductState{Open}}
             end
 
-            @testset "alias" begin
-                arrays = [rand(2, 2), rand(2, 2, 2), rand(2, 2)]
-                ψ = MatrixProductState{Open}(arrays, order = (:l, :p, :r))
+            @testset "Metadata" begin
+                @testset "alias" begin
+                    arrays = [rand(2, 2), rand(2, 2, 2), rand(2, 2)]
+                    ψ = MatrixProductState{Open}(arrays, order = (:l, :p, :r))
 
-                @test ψ.meta[:order] == Dict(:l => 1, :p => 2, :r => 3)
+                    @test ψ.meta[:order] == Dict(:l => 1, :p => 2, :r => 3)
 
-                @test issetequal(keys(tensors(ψ, 1).meta[:alias]), [:r, :p])
-                @test issetequal(keys(tensors(ψ, 2).meta[:alias]), [:l, :r, :p])
-                @test issetequal(keys(tensors(ψ, 3).meta[:alias]), [:l, :p])
+                    @test issetequal(keys(tensors(ψ, 1).meta[:alias]), [:r, :p])
+                    @test issetequal(keys(tensors(ψ, 2).meta[:alias]), [:l, :r, :p])
+                    @test issetequal(keys(tensors(ψ, 3).meta[:alias]), [:l, :p])
 
-                @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
-                @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
+                    @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
+                    @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
+                end
             end
         end
 
@@ -103,19 +105,21 @@
                 MatrixProductState{Closed}(arrays) isa TensorNetwork{MatrixProductState{Closed}}
             end
 
-            @testset "alias" begin
-                arrays = [rand(2, 2, 2), rand(2, 2, 2), rand(2, 2, 2)]
-                ψ = MatrixProductState{Closed}(arrays, order = (:r, :p, :l))
+            @testset "Metadata" begin
+                @testset "alias" begin
+                    arrays = [rand(2, 2, 2), rand(2, 2, 2), rand(2, 2, 2)]
+                    ψ = MatrixProductState{Closed}(arrays, order = (:r, :p, :l))
 
-                @test ψ.meta[:order] == Dict(:r => 1, :p => 2, :l => 3)
+                    @test ψ.meta[:order] == Dict(:r => 1, :p => 2, :l => 3)
 
-                @test issetequal(keys(tensors(ψ, 1).meta[:alias]), [:l, :r, :p])
-                @test issetequal(keys(tensors(ψ, 2).meta[:alias]), [:l, :r, :p])
-                @test issetequal(keys(tensors(ψ, 3).meta[:alias]), [:l, :r, :p])
+                    @test issetequal(keys(tensors(ψ, 1).meta[:alias]), [:l, :r, :p])
+                    @test issetequal(keys(tensors(ψ, 2).meta[:alias]), [:l, :r, :p])
+                    @test issetequal(keys(tensors(ψ, 3).meta[:alias]), [:l, :r, :p])
 
-                @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
-                @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
-                @test tensors(ψ, 3).meta[:alias][:r] === tensors(ψ, 1).meta[:alias][:l]
+                    @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
+                    @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
+                    @test tensors(ψ, 3).meta[:alias][:r] === tensors(ψ, 1).meta[:alias][:l]
+                end
             end
         end
     end

--- a/test/MatrixProductState_test.jl
+++ b/test/MatrixProductState_test.jl
@@ -35,10 +35,12 @@
                 MatrixProductState{Open}(arrays) isa TensorNetwork{MatrixProductState{Open}}
             end
 
-            # custom order
-            @test begin
+            @testset "custom order" begin
                 arrays = [rand(3, 1), rand(3, 1, 3), rand(1, 3)]
-                MatrixProductState{Open}(arrays, order = (:r, :p, :l)) isa TensorNetwork{MatrixProductState{Open}}
+                ψ = MatrixProductState{Open}(arrays, order = (:r, :p, :l))
+
+                @test ψ isa TensorNetwork{MatrixProductState{Open}}
+                @test ψ.meta[:order] == Dict(:r => 1, :p => 2, :l => 3)
             end
 
             # alternative constructor
@@ -56,6 +58,8 @@
             @testset "`Tensor.meta[:alias]`" begin
                 arrays = [rand(2, 2), rand(2, 2, 2), rand(2, 2)]
                 ψ = MatrixProductState{Open}(arrays, order = (:l, :p, :r))
+
+                @test ψ.meta[:order] == Dict(:l => 1, :p => 2, :r => 3)
 
                 @test issetequal(keys(tensors(ψ, 1).meta[:alias]), [:r, :p])
                 @test issetequal(keys(tensors(ψ, 2).meta[:alias]), [:l, :r, :p])
@@ -79,10 +83,12 @@
                 MatrixProductState{Closed}(arrays) isa TensorNetwork{MatrixProductState{Closed}}
             end
 
-            # custom order
-            @test begin
+            @testset "custom order" begin
                 arrays = [rand(3, 1, 3), rand(3, 1, 3), rand(3, 1, 3)]
-                MatrixProductState{Closed}(arrays, order = (:r, :p, :l)) isa TensorNetwork{MatrixProductState{Closed}}
+                ψ = MatrixProductState{Closed}(arrays, order = (:r, :p, :l))
+
+                @test ψ isa TensorNetwork{MatrixProductState{Closed}}
+                @test ψ.meta[:order] == Dict(:r => 1, :p => 2, :l => 3)
             end
 
             # alternative constructor
@@ -95,6 +101,21 @@
             @test_throws DimensionMismatch begin
                 arrays = [rand(1, 2), rand(1, 1, 2), rand(1, 2)]
                 MatrixProductState{Closed}(arrays) isa TensorNetwork{MatrixProductState{Closed}}
+            end
+
+            @testset "`Tensor.meta[:alias]`" begin
+                arrays = [rand(2, 2, 2), rand(2, 2, 2), rand(2, 2, 2)]
+                ψ = MatrixProductState{Closed}(arrays, order = (:r, :p, :l))
+
+                @test ψ.meta[:order] == Dict(:r => 1, :p => 2, :l => 3)
+
+                @test issetequal(keys(tensors(ψ, 1).meta[:alias]), [:l, :r, :p])
+                @test issetequal(keys(tensors(ψ, 2).meta[:alias]), [:l, :r, :p])
+                @test issetequal(keys(tensors(ψ, 3).meta[:alias]), [:l, :r, :p])
+
+                @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
+                @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
+                @test tensors(ψ, 3).meta[:alias][:r] === tensors(ψ, 1).meta[:alias][:l]
             end
         end
     end

--- a/test/MatrixProductState_test.jl
+++ b/test/MatrixProductState_test.jl
@@ -55,7 +55,7 @@
                 MatrixProductState{Open}(arrays) isa TensorNetwork{MatrixProductState{Open}}
             end
 
-            @testset "`Tensor.meta[:alias]`" begin
+            @testset "alias" begin
                 arrays = [rand(2, 2), rand(2, 2, 2), rand(2, 2)]
                 ψ = MatrixProductState{Open}(arrays, order = (:l, :p, :r))
 
@@ -103,7 +103,7 @@
                 MatrixProductState{Closed}(arrays) isa TensorNetwork{MatrixProductState{Closed}}
             end
 
-            @testset "`Tensor.meta[:alias]`" begin
+            @testset "alias" begin
                 arrays = [rand(2, 2, 2), rand(2, 2, 2), rand(2, 2, 2)]
                 ψ = MatrixProductState{Closed}(arrays, order = (:r, :p, :l))
 


### PR DESCRIPTION
This PR addresses the issue "Incorporate `labels` representation for physical indices of each `Tensor` within a `State`" (fix #49). The implementation enhances the `meta` field of a `Tensor` within a `State` or `Operator` by including a dictionary that links the physical representation of each index (left, right, ...) with its respective label. This feature has been implemented for all the currently supported structs, `MatrixProductState` and `MatrixProductOperator`.

Implemented changes:

1. Updated the code for `MatrixProductState{Open}`, `MatrixProductState{Closed}`, `MatrixProductOperator{Open}`, and `MatrixProductOperator{Closed}` to include the new `alias` dictionary within the `meta` field of a `Tensor`.
2. Added test cases to ensure that the `alias` dictionaries in the tensors are correct.

Here's an example showcasing the new `meta` field with the alias dictionary:
```julia
julia> using Tenet

julia> ψ = rand(MatrixProductOperator{Open}, 4, 2, 8, 4)
TensorNetwork{MatrixProductOperator{Open}}(#tensors=4, #inds=11)

julia> one = tensors(ψ, 1); one.meta
Dict{Symbol, Any} with 2 entries:
  :tags  => Set{String}()
  :alias => Dict(:o=>Symbol("6a835717-eb51-403b-85e8-3ad4b439f4b0"), :r=>Symbol("95d79e6d-82b0-4c7d-bb0c-f55398890b4c"), :i=>Symbol("5d0684da-9155-4f61-a6b5-ea5b7702702f"))

julia> two = tensors(ψ, 2); two.meta
Dict{Symbol, Any} with 2 entries:
  :tags  => Set{String}()
  :alias => Dict(:l=>Symbol("95d79e6d-82b0-4c7d-bb0c-f55398890b4c"), :o=>Symbol("00e4f5f1-ba5e-4188-afaf-59c362a6373e"), :r=>Symbol("f39496ab-1d95-4075-8365-d3f343a5f2d3"), :i=>Symbol("3f03c23f-11ca-4b2f-9a5d-2dc10fd1b16f"))

julia> one.meta[:alias][:r] === two.meta[:alias][:l]
true
```