### PR TITLE
Fix `rand` function for odd-length `MatrixProductState`

### DIFF
--- a/src/Quantum/MatrixProductState.jl
+++ b/src/Quantum/MatrixProductState.jl
@@ -153,7 +153,7 @@ function Base.rand(rng::Random.AbstractRNG, sampler::MPSSampler{Open,T}) where {
             χr = min(χ, p^i)
 
             # swap bond dims after mid and handle midpoint for odd-length MPS
-            (n % 2 == 1 && i == n ÷ 2 + 1) ? (χl, χl) : (after_mid ? (χr, χl) : (χl, χr))
+            (isodd(n) && i == n ÷ 2 + 1) ? (χl, χl) : (after_mid ? (χr, χl) : (χl, χr))
         end
 
         # fix for first site

--- a/src/Quantum/MatrixProductState.jl
+++ b/src/Quantum/MatrixProductState.jl
@@ -48,6 +48,8 @@ function MatrixProductState{Open}(arrays; χ = nothing, order = (:l, :r, :p), me
 
         invpermute!(labels, permutator)
         alias = Dict([x => y for (x, y) in zip(invpermute!(original_order, permutator), labels)])
+
+        println("site $i, size $(size(data)), labels $labels, alias $alias")
         push!(tn, Tensor(data, labels; alias = alias))
     end
 
@@ -151,8 +153,8 @@ function Base.rand(rng::Random.AbstractRNG, sampler::MPSSampler{Open,T}) where {
             χl = min(χ, p^(i - 1))
             χr = min(χ, p^i)
 
-            # swap bond dims after mid
-            after_mid ? (χr, χl) : (χl, χr)
+            # swap bond dims after mid and handle midpoint for odd-length MPS
+            (n % 2 == 1 && i == n ÷ 2 + 1) ? (χl, χl) : (after_mid ? (χr, χl) : (χl, χr))
         end
 
         # fix for first site

--- a/src/Quantum/MatrixProductState.jl
+++ b/src/Quantum/MatrixProductState.jl
@@ -49,7 +49,6 @@ function MatrixProductState{Open}(arrays; χ = nothing, order = (:l, :r, :p), me
         invpermute!(labels, permutator)
         alias = Dict([x => y for (x, y) in zip(invpermute!(original_order, permutator), labels)])
 
-        println("site $i, size $(size(data)), labels $labels, alias $alias")
         push!(tn, Tensor(data, labels; alias = alias))
     end
 

--- a/test/MatrixProductState_test.jl
+++ b/test/MatrixProductState_test.jl
@@ -55,6 +55,26 @@
                 MatrixProductState{Open}(arrays) isa TensorNetwork{MatrixProductState{Open}}
             end
 
+            @testset "rand" begin
+                function max_size(t)
+                    labels = (get(t.meta[:alias], :l, :none), get(t.meta[:alias], :r, :none))
+                    return maximum(size(t, label) for label in labels if label != :none)
+                end
+
+                # Test with χ > maximum possible χ for the given parameters
+                ψ = rand(MatrixProductState{Open}, 7, 2, 32)
+
+                @test ψ isa TensorNetwork{MatrixProductState{Open}}
+                @test length(ψ) == 7
+                @test maximum(max_size(t) for t in ψ.tensors) <= 32
+
+                # Test with χ < maximum possible χ for the given parameters
+                ψ = rand(MatrixProductState{Open}, 7, 2, 4)
+                @test ψ isa TensorNetwork{MatrixProductState{Open}}
+                @test length(ψ) == 7
+                @test maximum(max_size(t) for t in ψ.tensors) <= 4
+            end
+
             @testset "Metadata" begin
                 @testset "alias" begin
                     arrays = [rand(2, 2), rand(2, 2, 2), rand(2, 2)]


### PR DESCRIPTION
This PR addresses the issue with the `rand` function for generating random `MatrixProductStates` (MPS) with an odd number of tensors. Previously, the function produced an error when the number of tensors in the argument was odd:
```julia
julia> ψ = rand(MatrixProductState{Open}, 7, 2, 32)
ERROR: DimensionMismatch: size(9edf0aa5-219f-4849-99d3-a85b569b6773)=16 but should be 8
```

Now, the `rand` function correctly handles cases where the number of tensors is odd. Also, we have added tests to ensure its correct behavior.