### PR TITLE
Refactor `metadata` field in `TensorNetwork` to parametric `NamedTuple` type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,6 +23,14 @@ Tensors = "a57d67a0-4683-47ff-be60-6114e830558b"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 ValSplit = "0625e100-946b-11ec-09cd-6328dd093154"
 
+[weakdeps]
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+Quac = "b9105292-1415-45cf-bff1-d6ccf71e6143"
+
+[extensions]
+TenetMakieExt = "Makie"
+TenetQuacExt = "Quac"
+
 [compat]
 Combinatorics = "1.0"
 DeltaArrays = "0.1.0"
@@ -39,11 +47,3 @@ Requires = "1.3"
 Tensors = "0.1.4"
 ValSplit = "0.1"
 julia = "1.8"
-
-[extensions]
-TenetMakieExt = "Makie"
-TenetQuacExt = "Quac"
-
-[weakdeps]
-Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
-Quac = "b9105292-1415-45cf-bff1-d6ccf71e6143"

--- a/Project.toml
+++ b/Project.toml
@@ -32,6 +32,7 @@ TenetMakieExt = "Makie"
 TenetQuacExt = "Quac"
 
 [compat]
+Bijections = "0.1"
 Combinatorics = "1.0"
 DeltaArrays = "0.1.0"
 EinExprs = "0.1.1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Sergio Sánchez Ramírez <sergio.sanchez.ramirez@bsc.es>"]
 version = "0.1.1"
 
 [deps]
+Bijections = "e2ed5e7c-b2de-5872-ae92-c73ca462fb04"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 DeltaArrays = "10b0fc19-5ccc-4427-889b-d75dd6306188"
 EinExprs = "b1794770-133b-4de1-afb4-526377e9f4c5"

--- a/ext/TenetQuacExt.jl
+++ b/ext/TenetQuacExt.jl
@@ -37,8 +37,8 @@ function Tenet.TensorNetwork(circuit::Circuit)
     end
 
     for (lane, wireindices) in enumerate(wire)
-        tn[:plug][(lane, :in)] = wireindices[1]
-        tn[:plug][(lane, :out)] = wireindices[2]
+        tn.plug[(lane, :in)] = wireindices[1]
+        tn.plug[(lane, :out)] = wireindices[2]
     end
 
     return tn

--- a/ext/TenetQuacExt.jl
+++ b/ext/TenetQuacExt.jl
@@ -7,12 +7,13 @@ else
 end
 
 using Quac: Circuit, lanes, arraytype, Swap
+using Bijections
 
 function Tenet.TensorNetwork(circuit::Circuit)
-    tn = TensorNetwork{Quantum}(; plug = Dict{Tuple{Int,Symbol},Symbol}())
     n = lanes(circuit)
-
     wire = [[Tenet.letter(i)] for i in 1:n]
+    tensors = Tensor[]
+
     i = n + 1
 
     for gate in circuit
@@ -33,15 +34,15 @@ function Tenet.TensorNetwork(circuit::Circuit)
         end |> x -> zip(x...) |> Iterators.flatten |> collect
 
         tensor = Tensor(array, tuple(inds...); gate = gate)
-        push!(tn, tensor)
+        push!(tensors, tensor)
     end
 
-    for (lane, wireindices) in enumerate(wire)
-        tn.plug[(lane, :in)] = wireindices[1]
-        tn.plug[(lane, :out)] = wireindices[2]
-    end
+    interlayer = [
+        Bijection(Dict([site => first(index) for (site, index) in enumerate(wire)])),
+        Bijection(Dict([site => last(index) for (site, index) in enumerate(wire)])),
+    ]
 
-    return tn
+    return TensorNetwork{Quantum}(tensors; plug = Tenet.Operator, interlayer)
 end
 
 end

--- a/src/Helpers.jl
+++ b/src/Helpers.jl
@@ -66,3 +66,13 @@ julia> letter(20204)
 """
 letter(i) =
     Iterators.drop(Iterators.filter(isletter, Iterators.map(Char, 1:2^21-1)), i - 1) |> iterate |> first |> Symbol
+
+Base.merge(@nospecialize(A::Type{<:NamedTuple}), @nospecialize(Bs::Type{<:NamedTuple}...)) = NamedTuple{
+    foldl((acc, B) -> (acc..., B...), Iterators.map(fieldnames, Bs); init = fieldnames(A)),
+    foldl((acc, B) -> Tuple{fieldtypes(acc)...,B...}, Iterators.map(fieldtypes, Bs); init = A),
+}
+
+function superansatzes(T)
+    S = supertype(T)
+    return T === Ansatz ? (T,) : (T, superansatzes(S)...)
+end

--- a/src/Quantum/MP.jl
+++ b/src/Quantum/MP.jl
@@ -12,15 +12,17 @@ function MatrixProduct{P}(arrays; boundary::Type{<:Boundary} = Open, kwargs...) 
     MatrixProduct{P,boundary}(arrays; kwargs...)
 end
 
+metadata(::Type{<:MatrixProduct}) = NamedTuple{(:χ,),Tuple{Int}}
+
 function checkmeta(::Type{MatrixProduct{P,B}}, tn::TensorNetwork) where {P,B}
     # meta exists
     haskey(tn.metadata, :χ) || return false
 
     # meta has correct type
-    isnothing(tn[:χ]) || tn[:χ] isa Integer && tn[:χ] > 0 || return false
+    tn[:χ] > 0 || return false
 
     # no virtual index has dimensionality bigger than χ
-    isnothing(tn[:χ]) || all(i -> size(tn, i) <= tn[:χ], labels(tn, :inner)) || return false
+    all(i -> size(tn, i) <= tn[:χ], labels(tn, :inner)) || return false
 
     return true
 end

--- a/src/Quantum/MP.jl
+++ b/src/Quantum/MP.jl
@@ -82,7 +82,7 @@ function MatrixProduct{P,B}(
         Tensor(array, labels; alias = alias)
     end
 
-    return TensorNetwork{MatrixProduct{P,B}}(tensors; χ, interlayer, metadata...)
+    return TensorNetwork{MatrixProduct{P,B}}(tensors; χ, plug = P, interlayer, metadata...)
 end
 
 # NOTE does not use optimal contraction path, but "parallel-optimal" which costs x2 more

--- a/src/Quantum/MP.jl
+++ b/src/Quantum/MP.jl
@@ -2,6 +2,7 @@ using UUIDs: uuid4
 using Base.Iterators: flatten
 using IterTools: partition
 using Random
+using Bijections
 
 abstract type MatrixProduct{P,B} <: Quantum where {P<:Plug,B<:Boundary} end
 
@@ -12,17 +13,14 @@ function MatrixProduct{P}(arrays; boundary::Type{<:Boundary} = Open, kwargs...) 
     MatrixProduct{P,boundary}(arrays; kwargs...)
 end
 
-metadata(::Type{<:MatrixProduct}) = NamedTuple{(:χ,),Tuple{Int}}
+metadata(::Type{<:MatrixProduct}) = NamedTuple{(:χ,),Tuple{Union{Nothing,Int}}}
 
 function checkmeta(::Type{MatrixProduct{P,B}}, tn::TensorNetwork) where {P,B}
-    # meta exists
-    haskey(tn.metadata, :χ) || return false
-
     # meta has correct type
-    tn[:χ] > 0 || return false
+    isnothing(tn.χ) || tn.χ > 0 || return false
 
     # no virtual index has dimensionality bigger than χ
-    all(i -> size(tn, i) <= tn[:χ], labels(tn, :inner)) || return false
+    all(i -> isnothing(tn.χ) || size(tn, i) <= tn.χ, labels(tn, :virtual)) || return false
 
     return true
 end
@@ -57,8 +55,13 @@ function MatrixProduct{P,B}(
     oinds = Dict(i => Symbol(uuid4()) for i in 1:n)
     iinds = Dict(i => Symbol(uuid4()) for i in 1:n)
 
-    # mark plug connectors
-    plug = Dict((site, :out) => label for (site, label) in oinds)
+    interlayer = if P <: State
+        [Bijection(oinds)]
+    elseif P <: Operator
+        [Bijection(iinds), Bijection(oinds)]
+    else
+        throw(ErrorException("Plug $P is not valid"))
+    end
 
     tensors = map(enumerate(arrays)) do (i, array)
         dirs = _sitealias(MatrixProduct{P,B}, order, n, i)
@@ -79,7 +82,7 @@ function MatrixProduct{P,B}(
         Tensor(array, labels; alias = alias)
     end
 
-    return TensorNetwork{MatrixProduct{P,B}}(tensors; χ, plug, metadata...)
+    return TensorNetwork{MatrixProduct{P,B}}(tensors; χ, interlayer, metadata...)
 end
 
 # NOTE does not use optimal contraction path, but "parallel-optimal" which costs x2 more

--- a/src/Quantum/Quantum.jl
+++ b/src/Quantum/Quantum.jl
@@ -53,7 +53,7 @@ tensors(::Type{State}, tn::TensorNetwork{<:Quantum}, site) = select(tn, labels(t
 
 function Base.replace!(tn::TensorNetwork{<:Quantum}, old_new::Pair{Symbol,Symbol})
     # replace indices in tensor network
-    Base.@invoke replace!(tn::TensorNetwork, old_new)
+    Base.@invoke replace!(tn::TensorNetwork, old_new::Pair{Symbol,Symbol})
 
     old, new = old_new
 

--- a/src/Quantum/Quantum.jl
+++ b/src/Quantum/Quantum.jl
@@ -41,7 +41,7 @@ plug(::Type{T}) where {T<:TensorNetwork} = plug(ansatz(T))
 
 sites(tn::TensorNetwork) = collect(mapreduce(keys, ∪, tn.interlayer))
 
-labels(tn::TensorNetwork, ::Val{:plug}) = unique(Iterators.flatmap(values, tn.interlayer))
+labels(tn::TensorNetwork, ::Val{:plug}) = unique(Iterators.flatten(Iterators.map(values, tn.interlayer)))
 labels(tn::TensorNetwork, ::Val{:plug}, site) = last(tn.interlayer)[site] # labels(tn, Val(:in), site) ∪ labels(tn, Val(:out), site)
 labels(tn::TensorNetwork, ::Val{:virtual}) = setdiff(labels(tn, Val(:all)), labels(tn, Val(:plug)))
 

--- a/src/Quantum/Quantum.jl
+++ b/src/Quantum/Quantum.jl
@@ -9,12 +9,10 @@ Tensor Network [`Ansatz`](@ref) that has a notion of sites and directionality (i
 """
 abstract type Quantum <: Ansatz end
 
-function checkmeta(::Type{Quantum}, tn::TensorNetwork)
-    # meta exists
-    haskey(tn.metadata, :plug) || return false
+metadata(::Type{Quantum}) = NamedTuple{(:plug,),Dict{Tuple{Int,Symbol},Symbol}}
 
+function checkmeta(::Type{Quantum}, tn::TensorNetwork)
     # meta has correct type
-    tn[:plug] isa AbstractDict{Tuple{Int,Symbol},Symbol} || return false
     all(∈(:in, :out) ∘ last, keys(tn[:plug])) || return false
 
     # meta's indices exist

--- a/src/Quantum/Quantum.jl
+++ b/src/Quantum/Quantum.jl
@@ -97,13 +97,13 @@ Base.hcat(tns::TensorNetwork...) = reduce(hcat, tns)
 function Base.adjoint(tn::TensorNetwork{A}) where {A<:Quantum}
     tn = deepcopy(tn)
 
-    tn.plug = Dict((site, if dir === :in
+    copy!(tn.plug, Dict((site, if dir === :in
         :out
     elseif dir === :out
         :in
     else
         dir
-    end) => index for ((site, dir), index) in tn.plug)
+    end) => index for ((site, dir), index) in tn.plug))
 
     for tensor in tensors(tn)
         tensor .= conj(tensor)

--- a/src/Quantum/Quantum.jl
+++ b/src/Quantum/Quantum.jl
@@ -9,11 +9,11 @@ Tensor Network [`Ansatz`](@ref) that has a notion of sites and directionality (i
 """
 abstract type Quantum <: Ansatz end
 
-metadata(::Type{Quantum}) = NamedTuple{(:plug,),Dict{Tuple{Int,Symbol},Symbol}}
+metadata(::Type{Quantum}) = NamedTuple{(:plug,),Tuple{Dict{Tuple{Int,Symbol},Symbol}}}
 
 function checkmeta(::Type{Quantum}, tn::TensorNetwork)
     # meta has correct type
-    all(∈(:in, :out) ∘ last, keys(tn.plug)) || return false
+    all(∈((:in, :out)) ∘ last, keys(tn.plug)) || return false
 
     # meta's indices exist
     all(∈(keys(tn.indices)), values(tn.plug)) || return false

--- a/src/Quantum/Quantum.jl
+++ b/src/Quantum/Quantum.jl
@@ -12,11 +12,11 @@ abstract type Quantum <: Ansatz end
 metadata(::Type{Quantum}) = NamedTuple{(:plug,),Tuple{Dict{Tuple{Int,Symbol},Symbol}}}
 
 function checkmeta(::Type{Quantum}, tn::TensorNetwork)
-    # meta has correct type
-    all(∈((:in, :out)) ∘ last, keys(tn.plug)) || return false
+    # TODO run this check depending if State or Operator
+    last.(keys(tn.plug)) ⊆ (:in, :out) || return false
 
     # meta's indices exist
-    all(∈(keys(tn.indices)), values(tn.plug)) || return false
+    values(tn.plug) ⊆ keys(tn.indices) || return false
 
     # meta's indices are not repeated
     allunique(values(tn.plug)) || return false

--- a/src/Quantum/Quantum.jl
+++ b/src/Quantum/Quantum.jl
@@ -53,7 +53,7 @@ tensors(::Type{State}, tn::TensorNetwork{<:Quantum}, site) = select(tn, labels(t
 
 function Base.replace!(tn::TensorNetwork{<:Quantum}, old_new::Pair{Symbol,Symbol})
     # replace indices in tensor network
-    @invoke replace!(tn::TensorNetwork, old_new)
+    Base.@invoke replace!(tn::TensorNetwork, old_new)
 
     old, new = old_new
 

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -100,7 +100,8 @@ Base.size(tn::TensorNetwork, i::Symbol) = size(tn.tensors[first(tn.indices[i])],
 Base.eltype(tn::TensorNetwork) = promote_type(eltype.(tensors(tn))...)
 
 Base.getindex(tn::TensorNetwork, key::Symbol) = tn.metadata[key]
-Base.propertynames(tn::TensorNetwork{A,NamedTuple{N}}) where {A,N} = tuple(fieldnames(tn)..., N...)
+Base.fieldnames(tn::T) where {T<:TensorNetwork} = fieldnames(T)
+Base.propertynames(tn::TensorNetwork{A,N}) where {A,N} = tuple(fieldnames(tn)..., fieldnames(N)...)
 Base.getproperty(tn::T, name::Symbol) where {T<:TensorNetwork} =
     if hasfield(T, name)
         getfield(tn, name)

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -108,8 +108,8 @@ Base.propertynames(tn::TensorNetwork{A,NamedTuple{N}}) where {A,N} = tuple(field
 Base.getproperty(tn::T, name::Symbol) where {T<:TensorNetwork} =
     if hasfield(T, name)
         getfield(tn, name)
-    elseif hasproperty(fieldtype(T, :metadata), name)
-        getproperty(getfield(tn, :metadata), name)
+    elseif hasfield(fieldtype(T, :metadata), name)
+        getfield(getfield(tn, :metadata), name)
     else
         throw(KeyError(name))
     end

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -42,7 +42,7 @@ struct TensorNetwork{A<:Ansatz,M<:NamedTuple}
         indices = Dict{Symbol,Vector{Int}}()
         tensors = Vector{Tensor}()
         M = merge(Tenet.metadata.(superansatzes(A))...)
-        metadata = M(metadata)
+        metadata = M((; metadata...))
 
         tn = new{A,M}(indices, tensors, metadata)
 

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -61,8 +61,8 @@ struct TensorNetwork{A<:Ansatz,M<:NamedTuple}
 end
 
 checktopology(::TensorNetwork{<:Ansatz}) = true
-checkmeta(::TensorNetwork{Ansatz}) = true
-checkmeta(::TensorNetwork{T}) where {T<:Ansatz} = checkmeta(supertype(T), tn)
+checkmeta(::Type{<:Ansatz}, ::TensorNetwork) = true
+checkmeta(tn::TensorNetwork{T}) where {T<:Ansatz} = all(A -> checkmeta(A, tn), superansatzes(T))
 
 metadata(::Type{<:Ansatz}) = NamedTuple{(),Tuple{}}
 
@@ -85,7 +85,7 @@ Base.length(x::TensorNetwork) = length(tensors(x))
 
 Base.copy(tn::TensorNetwork{A}) where {A} = TensorNetwork{A}(copy(tn.tensors); deepcopy(tn.metadata)...)
 
-ansatz(::Type{TensorNetwork{A}}) where {A} = A
+ansatz(::Type{<:TensorNetwork{A}}) where {A} = A
 ansatz(::TensorNetwork{A}) where {A} = A
 
 tensors(tn::TensorNetwork) = tn.tensors
@@ -131,7 +131,8 @@ end
 Base.append!(tn::TensorNetwork, t::AbstractVecOrTuple{<:Tensor}) = (foreach(Base.Fix1(push!, tn), t); tn)
 function Base.append!(A::TensorNetwork, B::TensorNetwork)
     append!(A, tensors(B))
-    merge!(A.metadata, B.metadata)
+    # TODO define behaviour
+    # merge!(A.metadata, B.metadata)
     return A
 end
 

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -38,13 +38,14 @@ struct TensorNetwork{A<:Ansatz,M<:NamedTuple}
     metadata::M
 
     function TensorNetwork{A}(tensors; metadata...) where {A}
-        indices = Dict{Symbol,Vector{Int}}([])
+        indices = reduce(enumerate(tensors); init = Dict{Symbol,Vector{Int}}([])) do dict, (i, tensor)
+            mergewith(vcat, dict, Dict([index => [i] for index in labels(tensor)]))
+        end
 
         M = merge(Tenet.metadata.(superansatzes(A))...)
         metadata = M((; metadata...))
 
-        tn = new{A,M}(indices, Tensor[], metadata)
-        append!(tn, tensors)
+        tn = new{A,M}(indices, tensors, metadata)
 
         checkansatz(tn)
         return tn

--- a/test/Helpers_test.jl
+++ b/test/Helpers_test.jl
@@ -12,4 +12,23 @@
         # NOTE probabilitic testing due to time taken by `letter`. refactor when `letter` is optimized.
         @test all(isletter ∘ only ∘ String, Iterators.map(letter, rand(1:Tenet.NUM_UNICODE_LETTERS, 1000)))
     end
+
+    @testset "merge" begin
+        N = NamedTuple{(),Tuple{}}
+        @test merge(N, N) === N
+
+        A = NamedTuple{(:a,),Tuple{Int}}
+        @test merge(A, N) === merge(N, A) === A
+
+        B = NamedTuple{(:b,),Tuple{Float64}}
+        @test merge(A, B) ===
+              merge(A, B, N) ===
+              merge(N, A, B) ===
+              merge(A, N, B) ===
+              NamedTuple{(:a, :b),Tuple{Int,Float64}}
+    end
+
+    @testset "superansatzes" begin
+        @test Tenet.superansatzes(Arbitrary) === (Arbitrary, Ansatz)
+    end
 end

--- a/test/MatrixProductOperator_test.jl
+++ b/test/MatrixProductOperator_test.jl
@@ -1,5 +1,5 @@
 @testset "MatrixProduct{Operator}" begin
-    using Tenet: Operator
+    using Tenet: Operator, Composite
 
     @testset "plug" begin
         @test plug(MatrixProduct{Operator}) === Operator
@@ -132,6 +132,30 @@
                           only(select(ψ, first(ψ.interlayer)[1])).meta[:alias][:l]
                 end
             end
+        end
+    end
+
+    @testset "hcat" begin
+        @test begin
+            arrays = [rand(2, 2), rand(2, 2)]
+            mps =  MatrixProduct{State,Open}(arrays)
+            arrays_o = [rand(2, 2, 2), rand(2, 2, 2)]
+            mpo = MatrixProduct{Operator}(arrays_o)
+            hcat(mps, mpo) isa TensorNetwork{<:Composite}
+        end
+
+        @test begin
+            arrays = [rand(2, 2), rand(2, 2)]
+            mps =  MatrixProduct{State,Open}(arrays)
+            arrays_o = [rand(2, 2, 2), rand(2, 2, 2)]
+            mpo = MatrixProduct{Operator}(arrays_o)
+            hcat(mpo, mps) isa TensorNetwork{<:Composite}
+        end
+
+        @test begin
+            arrays = [rand(2, 2, 2), rand(2, 2, 2)]
+            mpo = MatrixProduct{Operator}(arrays)
+            hcat(mpo, mpo) isa TensorNetwork{<:Composite}
         end
     end
 

--- a/test/MatrixProductOperator_test.jl
+++ b/test/MatrixProductOperator_test.jl
@@ -65,12 +65,15 @@
                     arrays = [rand(1, 2, 2), rand(1, 1, 2, 2), rand(1, 2, 2)]
                     ψ = MatrixProduct{Operator,Open}(arrays, order = (:l, :r, :i, :o))
 
-                    @test issetequal(keys(tensors(ψ, 1, :out).meta[:alias]), [:r, :i, :o])
-                    @test issetequal(keys(tensors(ψ, 2, :out).meta[:alias]), [:l, :r, :i, :o])
-                    @test issetequal(keys(tensors(ψ, 3, :out).meta[:alias]), [:l, :i, :o])
+                    # TODO refactor `select` with `tensors` with output selection
+                    @test issetequal(keys(only(select(ψ, last(ψ.interlayer)[1])).meta[:alias]), [:r, :i, :o])
+                    @test issetequal(keys(only(select(ψ, last(ψ.interlayer)[2])).meta[:alias]), [:l, :r, :i, :o])
+                    @test issetequal(keys(only(select(ψ, last(ψ.interlayer)[3])).meta[:alias]), [:l, :i, :o])
 
-                    @test tensors(ψ, 1, :out).meta[:alias][:r] === tensors(ψ, 2, :out).meta[:alias][:l]
-                    @test tensors(ψ, 2, :out).meta[:alias][:r] === tensors(ψ, 3, :out).meta[:alias][:l]
+                    @test only(select(ψ, last(ψ.interlayer)[1])).meta[:alias][:r] ===
+                          only(select(ψ, last(ψ.interlayer)[2])).meta[:alias][:l]
+                    @test only(select(ψ, last(ψ.interlayer)[2])).meta[:alias][:r] ===
+                          only(select(ψ, last(ψ.interlayer)[3])).meta[:alias][:l]
                 end
             end
         end
@@ -116,13 +119,17 @@
                     arrays = [rand(1, 1, 2, 2), rand(1, 1, 2, 2), rand(1, 1, 2, 2)]
                     ψ = MatrixProduct{Operator,Periodic}(arrays, order = (:l, :r, :i, :o))
 
-                    @test issetequal(keys(tensors(ψ, 1, :out).meta[:alias]), [:l, :r, :i, :o])
-                    @test issetequal(keys(tensors(ψ, 2, :out).meta[:alias]), [:l, :r, :i, :o])
-                    @test issetequal(keys(tensors(ψ, 3, :out).meta[:alias]), [:l, :r, :i, :o])
+                    # TODO refactor `select` with `tensors` with output selection
+                    @test issetequal(keys(only(select(ψ, first(ψ.interlayer)[1])).meta[:alias]), [:l, :r, :i, :o])
+                    @test issetequal(keys(only(select(ψ, first(ψ.interlayer)[2])).meta[:alias]), [:l, :r, :i, :o])
+                    @test issetequal(keys(only(select(ψ, first(ψ.interlayer)[3])).meta[:alias]), [:l, :r, :i, :o])
 
-                    @test tensors(ψ, 1, :out).meta[:alias][:r] === tensors(ψ, 2, :out).meta[:alias][:l]
-                    @test tensors(ψ, 2, :out).meta[:alias][:r] === tensors(ψ, 3, :out).meta[:alias][:l]
-                    @test tensors(ψ, 3, :out).meta[:alias][:r] === tensors(ψ, 1, :out).meta[:alias][:l]
+                    @test only(select(ψ, first(ψ.interlayer)[1])).meta[:alias][:r] ===
+                          only(select(ψ, first(ψ.interlayer)[2])).meta[:alias][:l]
+                    @test only(select(ψ, first(ψ.interlayer)[2])).meta[:alias][:r] ===
+                          only(select(ψ, first(ψ.interlayer)[3])).meta[:alias][:l]
+                    @test only(select(ψ, first(ψ.interlayer)[3])).meta[:alias][:r] ===
+                          only(select(ψ, first(ψ.interlayer)[1])).meta[:alias][:l]
                 end
             end
         end

--- a/test/MatrixProductState_test.jl
+++ b/test/MatrixProductState_test.jl
@@ -1,4 +1,6 @@
 @testset "MatrixProduct{State}" begin
+    using Tenet: Composite
+
     @testset "plug" begin
         @test plug(MatrixProduct{State}) === State
         @test all(T -> plug(MatrixProduct{State,T}) === State, [Open, Periodic])
@@ -127,6 +129,20 @@
                     @test tensors(ψ, 3).meta[:alias][:r] === tensors(ψ, 1).meta[:alias][:l]
                 end
             end
+        end
+    end
+
+    @testset "hcat" begin
+        @test begin
+            arrays = [rand(2, 2), rand(2, 2)]
+            mps =  MatrixProduct{State,Open}(arrays)
+            hcat(mps, mps) isa TensorNetwork{<:Composite}
+        end
+
+        @test begin
+            arrays = [rand(1, 1, 2), rand(1, 1, 2)]
+            mps =  MatrixProduct{State,Periodic}(arrays)
+            hcat(mps, mps) isa TensorNetwork{<:Composite}
         end
     end
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Bijections = "e2ed5e7c-b2de-5872-ae92-c73ca462fb04"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"

--- a/test/Quantum_test.jl
+++ b/test/Quantum_test.jl
@@ -6,11 +6,12 @@
 
     tn = TensorNetwork{MockState}(
         [Tensor(rand(2, 2), (:i, :k)), Tensor(rand(3, 2, 4), (:j, :k, :l))];
+        plug = State,
         interlayer = [Bijection(Dict([1 => :i, 2 => :j]))],
     )
 
     @testset "metadata" begin
-        @test fieldnames(Tenet.metadata(Quantum)) === (:interlayer,)
+        @test fieldnames(Tenet.metadata(Quantum)) === (:plug, :interlayer)
         @test Tenet.checkmeta(tn)
 
         @test hasproperty(tn, :interlayer)

--- a/test/Quantum_test.jl
+++ b/test/Quantum_test.jl
@@ -1,2 +1,52 @@
 @testset "Quantum" begin
+    tn = TensorNetwork{Quantum}([Tensor(rand(2), (:i,))]; plug = Dict([(1, :out) => :i]))
+
+    @testset "metadata" begin
+        @test fieldnames(Tenet.metadata(Quantum)) === (:plug,)
+        @test Tenet.checkmeta(tn)
+
+        @test hasproperty(tn, :plug)
+        @test tn.plug == Dict([(1, :out) => :i])
+    end
+
+    # TODO write tests for
+    # - boundary
+    # - plug
+    # - sites for :plug, :in, :out
+
+    @testset "sites" begin
+        @test sites(tn) == sites(tn; dir = :out) == [1]
+        @test isempty(sites(tn, dir = :in))
+    end
+
+    @testset "labels" begin
+        @test all(allequal, zip(labels(tn), labels(tn, set = :open), labels(tn, :plug), labels(tn, :out), (:i,)))
+        @test isempty(labels(tn, set = :inner))
+        @test isempty(labels(tn, set = :hyper))
+        @test isempty(labels(tn, set = :in))
+        @test isempty(labels(tn, set = :virtual))
+    end
+
+    # @testset "tensors" begin
+    #     @test tensors(tn) == tensors(tn, 1)
+    # end
+
+    @testset "adjoint" begin
+        adj = adjoint(tn)
+
+        @test sites(tn, dir = :out) == sites(adj, dir = :in)
+        @test isempty(sites(tn, dir = :in))
+        @test isempty(sites(adj, dir = :out))
+
+        @test labels(tn, set = :plug) == labels(adj, set = :plug)
+        @test labels(tn, set = :out) == labels(adj, set = :in)
+        @test isempty(labels(tn, set = :in))
+        @test isempty(labels(adj, set = :out))
+    end
+
+    @testset "hcat" begin
+        let tn = hcat(tn, tn')
+            # TODO
+        end
+    end
 end

--- a/test/Quantum_test.jl
+++ b/test/Quantum_test.jl
@@ -1,7 +1,10 @@
 @testset "Quantum" begin
     using Bijections
 
-    tn = TensorNetwork{Quantum}(
+    struct MockState <: Quantum end
+    Tenet.plug(::Type{MockState}) = State
+
+    tn = TensorNetwork{MockState}(
         [Tensor(rand(2, 2), (:i, :k)), Tensor(rand(3, 2, 4), (:j, :k, :l))];
         interlayer = [Bijection(Dict([1 => :i, 2 => :j]))],
     )
@@ -43,8 +46,11 @@
     end
 
     @testset "hcat" begin
-        let tn = hcat(tn, tn')
-            # TODO
+        let expectation = hcat(tn, tn')
+            @test issetequal(sites(expectation), sites(tn))
+            @test issetequal(labels(expectation, set = :plug), labels(tn, set = :plug))
+            @test isempty(labels(expectation, set = :open))
+            @test issetequal(labels(expectation, set = :inner), labels(expectation, set = :all))
         end
     end
 end

--- a/test/Quantum_test.jl
+++ b/test/Quantum_test.jl
@@ -4,52 +4,118 @@
     struct MockState <: Quantum end
     Tenet.plug(::Type{MockState}) = State
 
-    tn = TensorNetwork{MockState}(
+    struct MockOperator <: Quantum end
+    Tenet.plug(::Type{MockOperator}) = Operator
+
+    state = TensorNetwork{MockState}(
         [Tensor(rand(2, 2), (:i, :k)), Tensor(rand(3, 2, 4), (:j, :k, :l))];
         plug = State,
         interlayer = [Bijection(Dict([1 => :i, 2 => :j]))],
     )
 
-    @testset "metadata" begin
-        @test fieldnames(Tenet.metadata(Quantum)) === (:plug, :interlayer)
-        @test Tenet.checkmeta(tn)
+    operator = TensorNetwork{MockOperator}(
+        [Tensor(rand(2, 4, 2), (:a, :c, :d)), Tensor(rand(3, 4, 2, 5), (:b, :c, :e, :f))];
+        plug = Operator,
+        interlayer = [Bijection(Dict([1 => :a, 2 => :b])), Bijection(Dict([1 => :d, 2 => :e]))],
+    )
 
-        @test hasproperty(tn, :interlayer)
-        @test only(tn.interlayer) == Bijection(Dict([1 => :i, 2 => :j]))
+    @testset "metadata" begin
+        @testset "State" begin
+            @test Tenet.checkmeta(state)
+            @test hasproperty(state, :interlayer)
+            @test only(state.interlayer) == Bijection(Dict([1 => :i, 2 => :j]))
+        end
+
+        @testset "Operator" begin
+            @test Tenet.checkmeta(operator)
+            @test hasproperty(operator, :interlayer)
+            @test operator.interlayer == [Bijection(Dict([1 => :a, 2 => :b])), Bijection(Dict([1 => :d, 2 => :e]))]
+        end
+    end
+
+    @testset "plug" begin
+        @test plug(state) === State
+
+        @test plug(operator) === Operator
     end
 
     # TODO write tests for
     # - boundary
-    # - plug
+    # - tensors
 
     @testset "sites" begin
-        @test issetequal(sites(tn), [1, 2])
+        @test issetequal(sites(state), [1, 2])
+        @test issetequal(sites(operator), [1, 2])
     end
 
     @testset "labels" begin
-        @test issetequal(labels(tn), [:i, :j, :k, :l])
-        @test issetequal(labels(tn, set = :open), [:i, :j, :l])
-        @test issetequal(labels(tn, set = :plug), [:i, :j])
-        @test issetequal(labels(tn, set = :inner), [:k])
-        @test isempty(labels(tn, set = :hyper))
-        @test issetequal(labels(tn, set = :virtual), [:k, :l])
+        @testset "State" begin
+            @test issetequal(labels(state), [:i, :j, :k, :l])
+            @test issetequal(labels(state, set = :open), [:i, :j, :l])
+            @test issetequal(labels(state, set = :plug), [:i, :j])
+            @test issetequal(labels(state, set = :inner), [:k])
+            @test isempty(labels(state, set = :hyper))
+            @test issetequal(labels(state, set = :virtual), [:k, :l])
+        end
+
+        # TODO change the indices
+        @testset "Operator" begin
+            @test issetequal(labels(operator), [:a, :b, :c, :d, :e, :f])
+            @test issetequal(labels(operator, set = :open), [:a, :b, :d, :e, :f])
+            @test issetequal(labels(operator, set = :plug), [:a, :b, :d, :e])
+            @test issetequal(labels(operator, set = :inner), [:c])
+            @test isempty(labels(operator, set = :hyper))
+            @test_broken issetequal(labels(operator, set = :virtual), [:c])
+        end
     end
 
-    # @testset "tensors" begin
-    #     @test tensors(tn) == tensors(tn, 1)
-    # end
-
     @testset "adjoint" begin
-        adj = adjoint(tn)
+        @testset "State" begin
+            adj = adjoint(state)
 
-        @test issetequal(sites(tn), sites(adj))
-        @test all(i -> labels(tn, :plug, i) == labels(adj, :plug, i), sites(tn))
+            @test issetequal(sites(state), sites(adj))
+            @test all(i -> labels(state, :plug, i) == labels(adj, :plug, i), sites(state))
+        end
+
+        @testset "Operator" begin
+            adj = adjoint(operator)
+
+            @test issetequal(sites(operator), sites(adj))
+            @test_broken all(i -> labels(operator, :plug, i) == labels(adj, :plug, i), sites(operator))
+            @test all(i -> first(operator.interlayer)[i] == last(adj.interlayer)[i], sites(operator))
+            @test all(i -> last(operator.interlayer)[i] == first(adj.interlayer)[i], sites(operator))
+        end
     end
 
     @testset "hcat" begin
-        let expectation = hcat(tn, tn')
-            @test issetequal(sites(expectation), sites(tn))
-            @test issetequal(labels(expectation, set = :plug), labels(tn, set = :plug))
+        @testset "(State, State)" begin
+            expectation = hcat(state, state)
+            @test issetequal(sites(expectation), sites(state))
+            @test issetequal(labels(expectation, set = :plug), labels(state, set = :plug))
+            @test isempty(labels(expectation, set = :open))
+            @test issetequal(labels(expectation, set = :inner), labels(expectation, set = :all))
+        end
+
+        @testset "(State, Operator)" begin
+            expectation = hcat(state, operator)
+            @test issetequal(sites(expectation), sites(state))
+            @test_broken issetequal(labels(expectation, set = :plug), labels(operator, set = :plug))
+            @test_broken isempty(labels(expectation, set = :open))
+            @test_broken issetequal(labels(expectation, set = :inner), labels(expectation, set = :all))
+        end
+
+        @testset "(Operator, State)" begin
+            expectation = hcat(operator, state)
+            @test issetequal(sites(expectation), sites(state))
+            @test_broken issetequal(labels(expectation, set = :plug), labels(state, set = :plug))
+            @test_broken isempty(labels(expectation, set = :open))
+            @test_broken issetequal(labels(expectation, set = :inner), labels(expectation, set = :all))
+        end
+
+        @testset "(Operator, Operator)" begin
+            expectation = hcat(operator, operator)
+            @test issetequal(sites(expectation), sites(state))
+            @test issetequal(labels(expectation, set = :plug), labels(operator, set = :plug))
             @test isempty(labels(expectation, set = :open))
             @test issetequal(labels(expectation, set = :inner), labels(expectation, set = :all))
         end

--- a/test/Quantum_test.jl
+++ b/test/Quantum_test.jl
@@ -1,22 +1,2 @@
 @testset "Quantum" begin
-    using Tenet: TensorNetwork, ansatz, Quantum, sites
-    using Quac
-
-    @testset "hcat" begin
-        n = 2
-        qft = Quac.Algorithms.QFT(n)
-        tn = TensorNetwork(qft)
-
-        newtn = hcat(tn, tn)
-
-        @test ansatz(newtn) <: Tuple{Quantum,Quantum}
-        # @test all(isphysical, inds(newtn))
-        @test issetequal(sites(newtn), 1:2)
-        @test issetequal(sites(newtn, :in), sites(tn, :in))
-        @test issetequal(sites(newtn, :out), sites(tn, :out))
-        @test issetequal(labels(newtn, :in), labels(tn, :in))
-        @test issetequal(labels(newtn, :out), labels(tn, :out))
-
-        # TODO @test_throws ErrorException ...
-    end
 end

--- a/test/integration/Quac_test.jl
+++ b/test/integration/Quac_test.jl
@@ -17,4 +17,22 @@
         # TODO `physicalinds`,`virtualinds`
         # @test all(isphysical, inds(tn))
     end
+
+    @testset "hcat" begin
+        n = 2
+        qft = Quac.Algorithms.QFT(n)
+        tn = TensorNetwork(qft)
+
+        newtn = hcat(tn, tn)
+
+        @test ansatz(newtn) <: Composite(Quantum, Quantum)
+        # @test all(isphysical, inds(newtn))
+        @test issetequal(sites(newtn), 1:2)
+        @test issetequal(sites(newtn, :in), sites(tn, :in))
+        @test issetequal(sites(newtn, :out), sites(tn, :out))
+        @test issetequal(labels(newtn, :in), labels(tn, :in))
+        @test issetequal(labels(newtn, :out), labels(tn, :out))
+
+        # TODO @test_throws ErrorException ...
+    end
 end

--- a/test/integration/Quac_test.jl
+++ b/test/integration/Quac_test.jl
@@ -11,28 +11,19 @@
         @test tn isa TensorNetwork{Quantum}
 
         @test issetequal(sites(tn), 1:n)
-        @test issetequal(sites(tn, :in), 1:n)
-        @test issetequal(sites(tn, :out), 1:n)
-
-        # TODO `physicalinds`,`virtualinds`
-        # @test all(isphysical, inds(tn))
     end
 
-    @testset "hcat" begin
-        n = 2
-        qft = Quac.Algorithms.QFT(n)
-        tn = TensorNetwork(qft)
+    # TODO currently broken
+    # @testset "hcat" begin
+    #     n = 2
+    #     qft = Quac.Algorithms.QFT(n)
+    #     tn = TensorNetwork(qft)
 
-        newtn = hcat(tn, tn)
+    #     newtn = hcat(tn, tn)
 
-        @test ansatz(newtn) <: Composite(Quantum, Quantum)
-        # @test all(isphysical, inds(newtn))
-        @test issetequal(sites(newtn), 1:2)
-        @test issetequal(sites(newtn, :in), sites(tn, :in))
-        @test issetequal(sites(newtn, :out), sites(tn, :out))
-        @test issetequal(labels(newtn, :in), labels(tn, :in))
-        @test issetequal(labels(newtn, :out), labels(tn, :out))
+    #     @test ansatz(newtn) <: Composite(Quantum, Quantum)
+    #     @test issetequal(sites(newtn), 1:2)
 
-        # TODO @test_throws ErrorException ...
-    end
+    #     # TODO @test_throws ErrorException ...
+    # end
 end


### PR DESCRIPTION
This PR replaces the `metadata` dictionary proposed in #55 with a `NamedTuple` defined as a parameter of the `TensorNetwork` type.

```julia
# before this PR
struct TensorNetwork{A<:Ansatz} ... end

# after this PR
struct TensorNetwork{A<:Ansatz,N<:NamedTuple} ... end
```

This makes the `TensorNetwork` type a lil bit more cumbersome, but avoids mutability bugs and makes its use easier. It actually implements a kind of _attribute inheritance_ pattern that perfectly fits our use case.

With this PR, we can:
- Easily check if the appropriate metadata has been passed.
- Inherit metadata fields from ansatz super types (some kind of _attribute inheritance_ seen in C/C++/Java... almost any other OOP language).
- Avoid mutability issues of the `metadata` field: delete metadata, cast to incorrect type, ...

And because the `metadata` fields only depends on the `Ansatz`, it can be compiled without any recompilation or method invalidation problems.