### PR TITLE
Add `DiagonalReduction` transformation for `TensorNetwork`

### DIFF
--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -76,11 +76,10 @@ function transform!(tn::TensorNetwork, config::DiagonalReduction)
                 end
             end
 
-            repeated_labels = replace(collect(labels(tensor)), old => new) |> join
-            removed_label = filter(l -> l != old, labels(tensor)) |> join
+            repeated_labels = replace(collect(labels(tensor)), old => new)
+            removed_label = filter(l -> l != old, labels(tensor))
 
-            ein_code_str = "ein\"$repeated_labels->$removed_label\""
-            data = eval(Meta.parse("$(ein_code_str)($tensor)"))
+            data = EinCode((String.(repeated_labels),),[String.(removed_label)...])(tensor)
             tn.tensors[idx] = Tensor(data, filter(l -> l != old, labels(tensor)))
             delete!(tn.inds, old)
 

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -48,7 +48,7 @@ end
 struct DiagonalReduction <: Transformation end
 
 function transform!(tn::TensorNetwork, ::DiagonalReduction; output_inds=nothing, atol=1e-12)
-    output_inds === nothing ? openinds(tn) : output_inds
+    output_inds = output_inds === nothing ? openinds(tn) : output_inds
     queue = collect(keys(tn.tensors))
 
     while !isempty(queue) # loop over all tensors

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -2,15 +2,15 @@ using DeltaArrays
 
 abstract type Transformation end
 
-transform(tn::TensorNetwork, transformations) = (tn = copy(tn); transform!(tn, transformations); return tn)
+transform(tn::TensorNetwork, transformations; kwargs...) = (tn = copy(tn); transform!(tn, transformations; kwargs...); return tn)
 
 function transform! end
 
-transform!(tn::TensorNetwork, transformation::Type{<:Transformation}) = transform!(tn, transformation())
+transform!(tn::TensorNetwork, transformation::Type{<:Transformation}; kwargs...) = transform!(tn, transformation(); kwargs...)
 
-function transform!(tn::TensorNetwork, transformations)
+function transform!(tn::TensorNetwork, transformations; kwargs...)
     for transformation in transformations
-        transform!(tn, transformation)
+        transform!(tn, transformation; kwargs...)
     end
     return tn
 end
@@ -44,4 +44,63 @@ function transform!(tn::TensorNetwork, ::HyperindConverter)
     end
 end
 
-# TODO column reduction, diagonal reduction, rank simplification, split simplification
+struct DiagonalReduction <: Transformation end
+
+function transform!(tn::TensorNetwork, ::DiagonalReduction; output_inds=nothing, atol=1e-12)
+    output_inds = output_inds === nothing ? openinds(tn) : output_inds
+    queue = collect(keys(tn.tensors))
+    cache = Dict()
+
+    while !isempty(queue)
+        idx = pop!(queue)
+        tensor = tn.tensors[idx]
+        cache_key = ("dr", idx, objectid(tensor.data))
+
+        if haskey(cache, cache_key)
+            continue
+        end
+
+        diag_axes = find_diag_axes(tensor.data, atol)
+
+        if isempty(diag_axes)
+            cache[cache_key] = true
+            continue
+        end
+
+        for (i, j) in diag_axes
+            ix_i, ix_j = labels(tensor)[i], labels(tensor)[j]
+            new, old = (ix_j in output_inds) ? ((ix_i in output_inds) ? continue : (ix_j, ix_i)) : (ix_i, ix_j)
+
+            for other_idx in setdiff(keys(tn.tensors), idx)
+                other_tensor = tn.tensors[other_idx]
+                if old in labels(other_tensor)
+                    new_tensor = replace(other_tensor, old => new)
+                    tn.tensors[other_idx] = new_tensor
+                end
+            end
+
+            data = view(tensor, old => 1)
+            tn.tensors[idx] = Tensor(data, filter(l -> l != old, labels(tensor)))
+
+            !isempty(find_diag_axes(parent(tensor), atol)) && push!(queue, idx)
+        end
+    end
+
+    return tn
+end
+
+function find_diag_axes(x::AbstractArray, atol=1e-12)
+    ndims = size(x)
+
+    # Find all the potential diagonals
+    potential_diag_axes = [(i, j) for i in 1:length(ndims) for j in i+1:length(ndims) if ndims[i] == ndims[j]]
+
+    # Check what elements satisfy the condition
+    return filter(potential_diag_axes) do (d1, d2)
+        all(pairs(x)) do (idx, val)
+            idx[d1] == idx[d2] || abs(val) <= atol
+        end
+    end
+end
+
+# TODO column reduction, rank simplification, split simplification

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -79,6 +79,8 @@ function transform!(tn::TensorNetwork, config::DiagonalReduction)
             repeated_labels = replace(collect(labels(tensor)), old => new)
             removed_label = filter(l -> l != old, labels(tensor))
 
+            # TODO rewrite with `Tensors` when it supports it
+            # extract diagonal
             data = EinCode((String.(repeated_labels),),[String.(removed_label)...])(tensor)
             tn.tensors[idx] = Tensor(data, filter(l -> l != old, labels(tensor)))
             delete!(tn.inds, old)

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -85,7 +85,7 @@ function transform!(tn::TensorNetwork, config::DiagonalReduction)
             delete!(tn.inds, old)
 
             tensor = tn.tensors[idx]
-            diag_axes = find_diag_axes(parent(tensor), atol)
+            diag_axes = find_diag_axes(parent(tensor), config.atol)
         end
     end
 

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -58,7 +58,7 @@ function transform!(tn::TensorNetwork, config::DiagonalReduction)
         idx = pop!(queue)
         tensor = tn.tensors[idx]
 
-        diag_axes = find_diag_axes(parent(tensor), atol)
+        diag_axes = find_diag_axes(parent(tensor), config.atol)
 
         while !isempty(diag_axes) # loop over all diagonal axes
             (i, j) = pop!(diag_axes)

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -48,7 +48,7 @@ end
 struct DiagonalReduction <: Transformation end
 
 function transform!(tn::TensorNetwork, ::DiagonalReduction; output_inds=nothing, atol=1e-12)
-    output_inds = output_inds === nothing ? openinds(tn) : output_inds
+    output_inds === nothing ? openinds(tn) : output_inds
     queue = collect(keys(tn.tensors))
 
     while !isempty(queue) # loop over all tensors

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -3,7 +3,7 @@ using OMEinsum
 
 abstract type Transformation end
 
-transform(tn::TensorNetwork, transformations; kwargs...) = (tn = copy(tn); transform!(tn, transformations; kwargs...); return tn)
+transform(tn::TensorNetwork, transformations) = (tn = copy(tn); transform!(tn, transformations); return tn)
 
 function transform! end
 

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -47,7 +47,7 @@ end
 
 Base.@kwdef struct DiagonalReduction <: Transformation
     atol::Float64 = 1e-12
-    skip::Vector{Symbol} = Symbol[]
+    skip::Vector{Index} = Symbol[]
 end
 
 function transform!(tn::TensorNetwork, config::DiagonalReduction)

--- a/test/Transformations_test.jl
+++ b/test/Transformations_test.jl
@@ -42,8 +42,12 @@
             data2 = zeros(Float64, 2, 2, 2)
             for i in 1:2
                 for j in 1:2
-                    data[i, j, i, j, i] = 1 # second and fourth indices are diagonal in data
-                    data[j, i, i, i, j] = 2 # first and fifth indices are diagonal in data
+                    for k in 1:2
+                        # In data the 1st-4th and 2nd-5th indices are diagonal
+                        data[i, j, k, i, j] = k
+                        data[j, i, k, j, i] = k + 2
+                    end
+
                     data2[i, i, i] = 1 # all indices are diagonal in data2
                 end
             end
@@ -52,10 +56,13 @@
             B = Tensor(data2, (:j, :n, :o))
             C = Tensor(rand(2, 2, 2), (:k, :p, :q))
 
+            @test issetequal(find_diag_axes(parent(A)), [(1, 4), (2, 5)])
+            @test issetequal(find_diag_axes(parent(B)), [(1, 2), (1, 3), (2, 3)])
+
             tn = TensorNetwork([A, B, C])
             reduced = transform(tn, DiagonalReduction)
 
-            # Test that all tensors in tn2 have no diagonals
+            # Test that all tensors in reduced have no diagonals
             for tensor in reduced.tensors
                 @test isempty(find_diag_axes(parent(tensor)))
             end

--- a/test/Transformations_test.jl
+++ b/test/Transformations_test.jl
@@ -66,6 +66,9 @@
             for tensor in reduced.tensors
                 @test isempty(find_diag_axes(parent(tensor)))
             end
+
+            # Test that the resulting contraction contains the same as the original
+            @test contract(reduced) |> parent |> sum ≈ contract(tn) |> parent |> sum
         end
     end
 end

--- a/test/Transformations_test.jl
+++ b/test/Transformations_test.jl
@@ -33,4 +33,32 @@
 
         # TODO @test issetequal(neighbours())
     end
+
+    @testset "Local transformations" begin
+        @testset "DiagonalReduction" begin
+            using Tenet: DiagonalReduction, find_diag_axes
+
+            data = zeros(Float64, 2, 2, 2, 2, 2)
+            data2 = zeros(Float64, 2, 2, 2)
+            for i in 1:2
+                for j in 1:2
+                    data[i, j, i, j, i] = 1 # second and fourth indices are diagonal in data
+                    data[j, i, i, i, j] = 2 # first and fifth indices are diagonal in data
+                    data2[i, i, i] = 1 # all indices are diagonal in data2
+                end
+            end
+
+            A = Tensor(data, (:i, :j, :k, :l, :m))
+            B = Tensor(data2, (:j, :n, :o))
+            C = Tensor(rand(2, 2, 2), (:k, :p, :q))
+
+            tn = TensorNetwork([A, B, C])
+            reduced = transform(tn, DiagonalReduction)
+
+            # Test that all tensors in tn2 have no diagonals
+            for tensor in reduced.tensors
+                @test isempty(find_diag_axes(parent(tensor)))
+            end
+        end
+    end
 end


### PR DESCRIPTION
### Summary
This PR addresses the issue #14 (resolves #14) by introducing the `DiagonalReduction` transformation in the `transform!` function for `TensorNetwork`s. This transformation applies diagonal reduction (as defined [here](https://arxiv.org/pdf/2002.01935.pdf)) to simplify the tensor network while preserving its mathematical properties. The key idea is to minimize the number of indices by identifying tensors with a certain diagonal structure and collapsing these indices, potentially leading to computational efficiency.

In addition to the implementation of the transformation, this PR includes tests to ensure correctness and robustness of the new method.

### Example
```julia
julia> using Tenet

julia> data = [1.0 0.0; 0.0 1.0;;; 1.0 0.0; 0.0 1.0] # We can clearly see that the first and second indices are diagonal
2×2×2 Array{Float64, 3}:
[:, :, 1] =
 1.0  0.0
 0.0  1.0

[:, :, 2] =
 1.0  0.0
 0.0  1.0

julia> B = Tensor(rand(2, 2, 2), (:j, :l, :m))
2×2×2 Tensor{Float64, 3, Array{Float64, 3}}: ...

julia> tn = TensorNetwork([A, B])
TensorNetwork{Arbitrary}(#tensors=2, #inds=5)

julia> [labels(tensor) for tensor in tn.tensors]
2-element Vector{Tuple{Symbol, Symbol, Vararg{Symbol}}}:
 (:i, :k)
 (:i, :l, :m)
```
This example demonstrates how `DiagonalReduction` effectively reduces the dimension of the first tensor and updates the rest of the network accordingly.
