### PR TITLE
Fixed issue in `contract` function for `TensorNetwork`

### DIFF
--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -307,7 +307,7 @@ function Random.rand(
 end
 
 EinExprs.einexpr(tn::TensorNetwork; optimizer = Greedy, outputs = openinds(tn), kwargs...) =
-    einexpr(optimizer, EinExpr(tensors(tn), outputs); kwargs...)
+    einexpr(optimizer, EinExpr(tensors(tn), nameof.(outputs)); kwargs...)
 
 # TODO sequence of indices?
 # TODO what if parallel neighbour indices?

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -203,6 +203,16 @@
         @test targets ⊆ labels(slice)
     end
 
+    @testset "contract" begin
+        tn = rand(TensorNetwork, 5, 3)
+        @test contract(tn) isa Tensor
+
+        A = Tensor(rand(2, 2, 2), (:i, :j, :k))
+        B = Tensor(rand(2, 2, 2), (:k, :l, :m))
+        tn = TensorNetwork([A, B])
+        @test contract(tn) isa Tensor
+    end
+
     @testset "Base.replace!" begin
         using Tenet: openinds, hyperinds, select
 


### PR DESCRIPTION
The `contract` function for `TensorNetworks` raised an error when trying to contract a tensor network defined with a list of `Tensor`s. In this PR we have fixed this small problem and added tests covering the previous error.

To illustrate the issue, we provide an example of the previous error:
```julia
julia> using Tenet

julia> A = Tensor(rand(2, 2, 2), (:i, :j, :k))
2×2×2 Tensor{Float64, 3, Array{Float64, 3}}: ...

julia> B = Tensor(rand(2, 2, 2), (:j, :l, :m))
2×2×2 Tensor{Float64, 3, Array{Float64, 3}}: ...

julia> tn = TensorNetwork([A, B])
TensorNetwork{Arbitrary}(#tensors=2, #inds=5)

julia> contract(tn)
ERROR: MethodError: Cannot `convert` an object of type Index to an object of type Symbol
Closest candidates are:
  convert(::Type{T}, ::T) where T at Base.jl:61
  Symbol(::Any...) at strings/basic.jl:229
```

With this PR the problem no longer occurs:
```julia
julia> using Tenet
...
julia> contract(tn)
2×2×2×2 Tensor{Float64, 4, Array{Float64, 4}}:
[:, :, 1, 1] =
 0.718756  0.317039
 0.665384  0.576727

[:, :, 2, 1] =
 0.182248  0.224855
 0.350426  0.479966

[:, :, 1, 2] =
 0.644568  0.404929
 0.748414  0.795829

[:, :, 2, 2] =
 0.438436  0.199706
 0.413822  0.366387
 ```