### PR TITLE
Add `AntiDiagonalGauging` transformation for `TensorNetwork`

### DIFF
--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -3,7 +3,7 @@ using OMEinsum
 
 abstract type Transformation end
 
-transform(tn::TensorNetwork, transformations) = (tn = copy(tn); transform!(tn, transformations); return tn)
+transform(tn::TensorNetwork, transformations) = (tn = deepcopy(tn); transform!(tn, transformations); return tn)
 
 function transform! end
 

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -114,10 +114,8 @@ end
 
 function transform!(tn::TensorNetwork, config::AntiDiagonalGauging)
     skip_inds = isempty(config.skip) ? openinds(tn) : config.skip
-    queue = collect(keys(tn.tensors))
 
-    while !isempty(queue) # loop over all tensors
-        idx = pop!(queue)
+    for idx in keys(tn.tensors)
         tensor = tn.tensors[idx]
 
         anti_diag_axes = find_anti_diag_axes(parent(tensor), config.atol)

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -126,9 +126,9 @@ function transform!(tn::TensorNetwork, config::AntiDiagonalGauging)
             ix_i, ix_j = labels(tensor)[i], labels(tensor)[j]
 
             # do not gauge output indices
-            _, ix_to_gauge = (ix_j in skip_inds) ? ((ix_i in skip_inds) ? continue : (ix_j, ix_i)) : (ix_i, ix_j)
+            _, ix_to_gauge = (ix_j ∈ nameof.(skip_inds)) ? ((ix_i ∈ nameof.(skip_inds)) ? continue : (ix_j, ix_i)) : (ix_i, ix_j)
 
-            # flip the order of ix_to_gauge in all tensors where it appears
+            # reverse the order of ix_to_gauge in all tensors where it appears
             for t in tensors(tn)
                 ix_to_gauge in labels(t) && reverse!(parent(t), dims = findfirst(l -> l == ix_to_gauge, labels(t)))
             end
@@ -137,7 +137,6 @@ function transform!(tn::TensorNetwork, config::AntiDiagonalGauging)
 
     return tn
 end
-
 
 function find_anti_diag_axes(x::AbstractArray, atol=1e-12)
     ndims = size(x)
@@ -153,30 +152,5 @@ function find_anti_diag_axes(x::AbstractArray, atol=1e-12)
         end
     end
 end
-
-
-function view_index_plane(tensor::Tensor, ix::Symbol, iy::Symbol)
-    labels = tensor.labels
-    if ix ∉ labels || iy ∉ labels
-        error("Specified indices not found in tensor")
-    end
-
-    # Separate labels into those for our chosen indices and the rest
-    chosen_labels = [ix, iy]
-
-    # Collapse all other dimensions into one using EinCode
-    ein_code = EinCode((String.(collect(labels)),), [String.(chosen_labels)...])
-    reshaped_data = ein_code(tensor.data)
-
-    # # Check if the indices are in the right order and if not, swap them
-    # if labels[1] != ix || labels[2] != iy
-    #     reshaped_data = permutedims(reshaped_data, [findfirst(==(ix), labels), findfirst(==(iy), labels), collect(3:length(size(reshaped_data)))...])
-    # end
-
-    # Now we can return a view of the reshaped data, collapsing all dimensions after the second into one
-    new_dims = size(reshaped_data)
-    return view(reshaped_data, :, :, ones(Int, length(new_dims)-2)... )
-end
-
 
 # TODO column reduction, rank simplification, split simplification

--- a/test/Transformations_test.jl
+++ b/test/Transformations_test.jl
@@ -71,4 +71,34 @@
             @test contract(reduced) |> parent |> sum ≈ contract(tn) |> parent |> sum
         end
     end
+
+    @testset "AntiDiagonalGauging" begin
+        using Tenet: AntiDiagonalGauging, find_anti_diag_axes
+
+        d = 2  # size of indices
+
+        data = zeros(Float64, d, d, d, d, d)
+        data2 = zeros(Float64, d, d, d)
+        for i in 1:d
+            for j in 1:d
+                for k in 1:d
+                    # In data_anti the 1st-4th and 2nd-5th indices are antidiagonal
+                    data[i, j, k, d-i+1, d-j+1] = k
+                    data[j, i, k, d-j+1, d-i+1] = k + 2
+
+                    data2[i, d-i+1, k] = 1  # 1st-2nd indices are antidiagonal in data2_anti
+                end
+
+            end
+        end
+
+        A = Tensor(data, (:i, :j, :k, :l, :m))
+        B = Tensor(data2, (:j, :n, :o))
+        C = Tensor(rand(d, d, d), (:k, :p, :q))
+
+
+        tn = TensorNetwork([A, B, C])
+
+
+    end
 end

--- a/test/Transformations_test.jl
+++ b/test/Transformations_test.jl
@@ -73,7 +73,7 @@
     end
 
     @testset "AntiDiagonalGauging" begin
-        using Tenet: AntiDiagonalGauging, find_anti_diag_axes
+        using Tenet: AntiDiagonalGauging, find_anti_diag_axes, innerinds, labels
 
         function has_antidiagonal_in_innerinds(tensor, innerinds)
             for (i, j) in find_anti_diag_axes(parent(tensor))


### PR DESCRIPTION
### Summary
This PR addresses the issue #16 (resolves #16)  by introducing the `AntiDiagonalGauging` transformation in the `transform!` function for `TensorNetworks`. This transformation applies the anti-diagonal gauging (as defined [here](https://arxiv.org/pdf/2002.01935.pdf)) to modify the tensor network while preserving its mathematical properties.

The `AntiDiagonalGauging` transformation reverses the order of some indices for tensors that fulfill an anti-diagonal condition. While this transformation alone does not directly contribute to computational efficiency, it prepares the tensor network for further simplifications by creating tensors with diagonal indices. These tensors can then be simplified using the `DiagonalReduction` transformation, which was implemented in PR #58.

In addition to the implementation of the transformation, this PR includes tests to ensure the correctness and robustness of the new method.

### Example
```julia
julia> using Tenet

julia> data = [0.0 1.0; 1.0 0.0;;; 0.0 1.0; 1.0 0.0] # The first and second indices are anti-diagonal
2×2×2 Array{Float64, 3}:
[:, :, 1] =
 0.0  1.0
 1.0  0.0

[:, :, 2] =
 0.0  1.0
 1.0  0.0

julia> A = Tensor(data, (:i, :j, :k))
2×2×2 Tensor{Float64, 3, Array{Float64, 3}}: ...

julia> B = Tensor(rand(2, 2, 2), (:j, :k, :l))
2×2×2 Tensor{Float64, 3, Array{Float64, 3}}: ...

julia> tn = TensorNetwork([A, B])
TensorNetwork{Arbitrary}(#tensors=2, #inds=4)

julia> gauged_tn = transform(tn, Tenet.AntiDiagonalGauging)
TensorNetwork{Arbitrary}(#tensors=2, #inds=4)

julia> tensors(gauged_tn)[1] # We see that it now has a diagonal structure
2×2×2 Tensor{Float64, 3, Array{Float64, 3}}:
[:, :, 1] =
 1.0  0.0
 0.0  1.0

[:, :, 2] =
 1.0  0.0
 0.0  1.0

julia> contract(A, B) ≈ contract(tensors(gauged_tn)[1], tensors(gauged_tn)[2])
true
```

In this example, we illustrate how the `AntiDiagonalGauging` transformation converts a tensor with an anti-diagonal structure into one with a diagonal structure.

