### PR TITLE
Fix `DiagonalReduction` tranformation for reduction over `skip_inds`

### DIFF
--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -1,5 +1,6 @@
 using DeltaArrays
 using OMEinsum
+using UUIDs: uuid4
 
 abstract type Transformation end
 
@@ -90,8 +91,8 @@ function transform!(tn::TensorNetwork, config::DiagonalReduction)
             # if the new index is in skip_inds, we need to add a COPY tensor
             if new ∈ nameof.(skip_inds)
                 data = DeltaArray{replacements+2}(ones(size(tensor, new))) # +2 for the new COPY tensor and the old index
-                indices = [Symbol("$(new)$i") for i in 1:replacements+2]
-                copy_tensor = Tensor(data, indices)
+                indices = [Symbol(uuid4()) for i in 1:replacements+1]
+                copy_tensor = Tensor(data, (new, indices...))
 
                 # replace the new index in the other tensors in the network
                 counter = 1

--- a/test/Transformations_test.jl
+++ b/test/Transformations_test.jl
@@ -36,39 +36,84 @@
 
     @testset "Local transformations" begin
         @testset "DiagonalReduction" begin
-            using Tenet: DiagonalReduction, find_diag_axes
+            using Tenet: DiagonalReduction, find_diag_axes, innerinds
+            using DeltaArrays: DeltaArray
 
-            data = zeros(Float64, 2, 2, 2, 2, 2)
-            data2 = zeros(Float64, 2, 2, 2)
-            for i in 1:2
-                for j in 1:2
-                    for k in 1:2
-                        # In data the 1st-4th and 2nd-5th indices are diagonal
-                        data[i, j, k, i, j] = k
-                        data[j, i, k, j, i] = k + 2
+            function has_diagonal_in_innerinds(tensor, innerinds)
+                for (i, j) in find_diag_axes(parent(tensor))
+                    idx_i, idx_j = labels(tensor)[i], labels(tensor)[j]
+
+                    if idx_i ∈ nameof.(innerinds) || idx_j ∈ nameof.(innerinds)
+                        return true
                     end
-
-                    data2[i, i, i] = 1 # all indices are diagonal in data2
                 end
+                return false
             end
 
-            A = Tensor(data, (:i, :j, :k, :l, :m))
-            B = Tensor(data2, (:j, :n, :o))
-            C = Tensor(rand(2, 2, 2), (:k, :p, :q))
+            @testset "innerinds" begin
+                data = zeros(Float64, 2, 2, 2, 2)
+                for i in 1:2
+                    for j in 1:2
+                        for k in 1:2
+                            # In data the 1st-2th are diagonal
+                            data[i, i, j, k] = k
+                        end
+                    end
+                end
 
-            @test issetequal(find_diag_axes(parent(A)), [(1, 4), (2, 5)])
-            @test issetequal(find_diag_axes(parent(B)), [(1, 2), (1, 3), (2, 3)])
+                A = Tensor(data, (:i, :j, :k, :l))
+                B = Tensor(rand(2, 2), (:i, :m))
+                C = Tensor(rand(2, 2), (:j, :n))
 
-            tn = TensorNetwork([A, B, C])
-            reduced = transform(tn, DiagonalReduction)
+                @test issetequal(find_diag_axes(parent(A)), [(1, 2)])
 
-            # Test that all tensors in reduced have no diagonals
-            for tensor in reduced.tensors
-                @test isempty(find_diag_axes(parent(tensor)))
+                tn = TensorNetwork([A, B, C])
+                reduced = transform(tn, DiagonalReduction)
+
+                # Since the reduced dimensions are in innerinds, there are no COPY tensors
+                for tensor in tensors(reduced)
+                    @test isempty(find_diag_axes(parent(tensor)))
+                end
+
+                # Test that the resulting contraction returns the same as the original
+                # @test contract(reduced) ≈ contract(tn)
             end
 
-            # Test that the resulting contraction contains the same as the original
-            @test contract(reduced) |> parent |> sum ≈ contract(tn) |> parent |> sum
+            @testset "openinds" begin
+                data = zeros(Float64, 2, 2, 2, 2, 2)
+                data2 = zeros(Float64, 2, 2, 2)
+                for i in 1:2
+                    for j in 1:2
+                        for k in 1:2
+                            # In data the 1st-4th and 2nd-5th indices are diagonal
+                            data[i, j, k, i, j] = k
+                            data[j, i, k, j, i] = k + 2
+                        end
+
+                        data2[i, i, i] = 1 # all indices are diagonal in data2
+                    end
+                end
+
+                A = Tensor(data, (:i, :j, :k, :l, :m))
+                B = Tensor(data2, (:j, :n, :o))
+                C = Tensor(rand(2, 2, 2), (:k, :p, :q))
+
+                @test issetequal(find_diag_axes(parent(A)), [(1, 4), (2, 5)])
+                @test issetequal(find_diag_axes(parent(B)), [(1, 2), (1, 3), (2, 3)])
+
+                tn = TensorNetwork([A, B, C])
+                reduced = transform(tn, DiagonalReduction)
+
+                # Test that all tensors (that are no COPY tensors) in reduced have no
+                #  diagonals in the that are in innerinds
+                for tensor in filter(t -> !(parent(t) isa DeltaArray), tensors(reduced))
+                    @test has_diagonal_in_innerinds(tensor, innerinds(reduced)) == false
+                end
+
+                # Test that the resulting contraction returns the same as the original
+                # @test contract(reduced) ≈ contract(tn)
+            end
         end
+
     end
 end

--- a/test/Transformations_test.jl
+++ b/test/Transformations_test.jl
@@ -114,6 +114,5 @@
                 # @test contract(reduced) ≈ contract(tn)
             end
         end
-
     end
 end


### PR DESCRIPTION
### Summary
This PR addresses a previously overlooked scenario in the `DiagonalReduction` transformation of the `transform` function. Specifically, it targets instances where the index to be reduced is included in `skip_inds`, which is set to be the open indices of the network by default. In such cases, the transformation previously failed to correctly reduce the dimension of a `Tensor` in a `TensorNetwork`.

To fix this,  we have introduced a COPY tensor whenever an index is reduced over a `Tensor` with an index in `skip_inds`. to illustrate this, let's consider a `TensorNetwork` $`TN=T^{1}_{ijk}T^{2}_{jkl} `$, and we want to reduce the diagonal indices $ij$ where $i$ is on `skip_inds` since it is an open index. A regular reduction would lead to $`\tilde{TN}=T^{1}_{ik} T^{2}_{ikl}`$, but as a result, the index $i$ would no longer be an open index, and thus $`TN \neq \tilde{TN}`$. To ensure that the dimensionality of the two expressions is the same, we need to add a COPY tensor: $` {TN}^{\prime}=T^{1}_{i_{1} k} T^{2}_{i_{2} kl} \delta_{i_{1} i_{2} i_{3}}`$.

Additionally, we have refined the corresponding tests to better accommodate this specific scenario.

### Example
Below is an example illustrating a diagonal reduction wherein one of the indices is an open index, thus introducing a COPY tensor in the reduction:
```julia
julia> using Tenet

julia> data = [1.0 0.0; 0.0 1.0;;; 1.0 0.0; 0.0 1.0] # The first and second indices are diagonal
2×2×2 Array{Float64, 3}:
[:, :, 1] =
 1.0  0.0
 0.0  1.0

[:, :, 2] =
 1.0  0.0
 0.0  1.0

julia> A = Tensor(data, (:i, :j, :k))
2×2×2 Tensor{Float64, 3, Array{Float64, 3}}: ...

julia> B = Tensor(rand(2, 2, 2), (:j, :k, :l))
2×2×2 Tensor{Float64, 3, Array{Float64, 3}}: ...

julia> tn = TensorNetwork([A, B])
TensorNetwork{Arbitrary}(#tensors=2, #inds=4)

julia> reduced = transform(tn, DiagonalReduction)
TensorNetwork{Arbitrary}(#tensors=3, #inds=6)

julia> [labels(tensor) for tensor in reduced.tensors]
3-element Vector{Tuple{Symbol, Symbol, Vararg{Symbol}}}:
 (:i1, :k)
 (:i2, :k, :l)
 (:i1, :i2, :i3)
```