### PR TITLE
Implement `ColumnReduction` transformation for `TensorNetwork`

### DIFF
--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -217,6 +217,7 @@ function transform!(tn::TensorNetwork, config::ColumnReduction)
                     tn.tensors[ind] = Tensor(new_tensor, new_labels)
                 end
             end
+            delete!(tn.inds, ix_i)
         end
 
         # Then try to reduce the dimensionality of the index in the other tensors
@@ -236,7 +237,6 @@ function transform!(tn::TensorNetwork, config::ColumnReduction)
                     tn.tensors[ind] = Tensor(view(parent(t), reduced_dims...), labels(t))
                 end
             end
-            delete!(tn.inds, ix_i)
         end
     end
 

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -186,8 +186,7 @@ end
 function transform!(tn::TensorNetwork, config::ColumnReduction)
     skip_inds = isempty(config.skip) ? openinds(tn) : config.skip
 
-    for idx in keys(tn.tensors)
-        tensor = tn.tensors[idx]
+    for tensor in tn.tensors
 
         zero_columns = find_zero_columns(parent(tensor), atol=config.atol)
         zero_columns_by_axis = [filter(x -> x[1] == d, zero_columns) for d in 1:length(size(tensor))]

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -236,6 +236,7 @@ function transform!(tn::TensorNetwork, config::ColumnReduction)
                     tn.tensors[ind] = Tensor(view(parent(t), reduced_dims...), labels(t))
                 end
             end
+            delete!(tn.inds, ix_i)
         end
     end
 

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -187,7 +187,6 @@ function transform!(tn::TensorNetwork, config::ColumnReduction)
     skip_inds = isempty(config.skip) ? openinds(tn) : config.skip
 
     for tensor in tn.tensors
-
         zero_columns = find_zero_columns(parent(tensor), atol=config.atol)
         zero_columns_by_axis = [filter(x -> x[1] == d, zero_columns) for d in 1:length(size(tensor))]
 

--- a/test/Transformations_test.jl
+++ b/test/Transformations_test.jl
@@ -221,6 +221,8 @@
                 @test :j ∉ labels(tensor)
             end
 
+            @test length(tn.inds) > length(reduced.inds)
+
             # Test that the resulting contraction is the same as the original
             # TODO: Change for: @test contract(reduced) ≈ contract(tn), when is fixed
             A_2, B_2, C_2 = tensors(reduced)
@@ -245,6 +247,8 @@
                 @test isempty(find_zero_columns(parent(tensor)))
                 @test size(tensor, :j) == 2
             end
+
+            @test length(tn.inds) == length(reduced.inds)
 
             # Test that the resulting contraction is the same as the original
             # TODO: Change for: @test contract(reduced) ≈ contract(tn), when is fixed

--- a/test/Transformations_test.jl
+++ b/test/Transformations_test.jl
@@ -197,4 +197,30 @@
         A_2, B_2, C_2 = tensors(gauged)
         @test contract(A, contract(B, C)) ≈ contract(A_2, contract(B_2, C_2))
     end
+
+    @testset "ColumnReduction" begin
+        using Tenet: ColumnReduction, find_column_axes, labels
+
+        data = rand(3, 3, 3)
+        data[:,2,:] .= 0 # 2nd column of the 2nd dimension can be reduced
+
+        A = Tensor(data, (:i, :j, :k))
+        B = Tensor(rand(3, 3), (:j, :l))
+        C = Tensor(rand(3, 3), (:k, :m))
+
+        @test issetequal(find_column_axes(parent(A)), [(2, 2)])
+
+        tn = TensorNetwork([A, B, C])
+        reduced = transform(tn, ColumnReduction)
+
+        # Test that all the tensors in reduced have no columns
+        for tensor in tensors(reduced)
+            @test isempty(find_column_axes(parent(tensor)))
+        end
+
+        # Test that the resulting contraction is the same as the original
+        # TODO: Change for: @test contract(reduced) ≈ contract(tn), when is fixed
+        A_2, B_2, C_2 = tensors(reduced)
+        @test contract(A, contract(B, C)) ≈ contract(A_2, contract(B_2, C_2))
+    end
 end


### PR DESCRIPTION
### Summary
This PR addresses the issue #17 (resolves #17) by introducing the `ColumnReduction` transformation in the `transform!` function for `TensorNetwork`s. This transformation applies the column reduction (as defined [here](https://arxiv.org/pdf/2002.01935.pdf)) to simplify the tensor network. The key idea is to reduce the rank of the tensors that have a dimension where all but a "column" is filled with zeros.

Furthermore, we have extended the scope of this method to handle cases where more than one column contains non-zeros but specific columns are entirely zero-filled. This allows the reduction of the index dimensionality where columns are filled with zeros.

In addition to implementing the transformation, this PR includes tests to ensure the correctness and robustness of the new method.

### Example
The primary function of `ColumnReduction` is to decrease tensor rank where a dimension features only one non-zero 'column'. The following example illustrates this operation:
```julia
julia> using Tenet

julia> data = rand(3, 3, 3)
...

julia> data[:,1:2,:] .= 0 # 1st and 2nd column of the 2nd dimension are zero
...

julia> data # only 3rd columns is non-zero
3×3×3 Array{Float64, 3}:
[:, :, 1] =
 0.0  0.0  0.350011
 0.0  0.0  0.990275
 0.0  0.0  0.295394

[:, :, 2] =
 0.0  0.0  0.538989
 0.0  0.0  0.141018
 0.0  0.0  0.687099

[:, :, 3] =
 0.0  0.0  0.291134
 0.0  0.0  0.0972771
 0.0  0.0  0.614801

julia> A = Tensor(data, (:i, :j, :k)); B = Tensor(rand(3, 3), (:j, :l)); C = Tensor(rand(3, 3), (:j, :m))
3×3×3 Tensor{Float64, 3, Array{Float64, 3}}:
...

julia> tn = TensorNetwork([A, B, C])
TensorNetwork{Arbitrary}(#tensors=3, #inds=5)

julia> reduced = transform(tn, ColumnReduction)
TensorNetwork{Arbitrary}(#tensors=3, #inds=4)

julia> [labels(tensor) for tensor in reduced.tensors]
3-element Vector{Tuple{Symbol, Vararg{Symbol}}}:
 (:i, :k)
 (:l,)
 (:m,)
```
In this example, the column reduction transformation results in a network where the tensors are unconnected.

We now show how we enhanced the transformation to operate in scenarios where more than one non-zero column exists. The example below highlights such an instance:
```julia
julia> using Tenet

julia> data = rand(3, 3, 3)
...

julia> data[:,2,:] .= 0 # 2nd column of the 2nd dimension can be reduced
...

julia> data # 1st and 3rd column of the 2nd dimension are non-zero
3×3×3 Array{Float64, 3}:
[:, :, 1] =
 0.615815  0.0  0.245444
 0.26432   0.0  0.0888118
 0.812256  0.0  0.294028

[:, :, 2] =
 0.998973  0.0  0.0581316
 0.532386  0.0  0.764539
 0.503775  0.0  0.812196

[:, :, 3] =
 0.959305  0.0  0.812671
 0.717794  0.0  0.925235
 0.812287  0.0  0.54355

julia> A = Tensor(data, (:i, :j, :k)); B = Tensor(rand(3, 3), (:j, :l)); C = Tensor(rand(3, 3), (:j, :m))
3×3×3 Tensor{Float64, 3, Array{Float64, 3}}:
...

julia> tn = TensorNetwork([A, B, C])
TensorNetwork{Arbitrary}(#tensors=3, #inds=5)

julia> reduced = transform(tn, ColumnReduction)
TensorNetwork{Arbitrary}(#tensors=3, #inds=5)

julia> [size(tensor) for tensor in reduced.tensors]
3-element Vector{Tuple{Int64, Int64, Vararg{Int64}}}:
 (3, 2, 3)
 (2, 3)
 (2, 3)
```
In this example we show that when we have only one zero column in an index, we can apply a transformation to reduce the dimension of that index.