### PR TITLE
Fix `hcat` function to handle label replacement in tensor networks correctly

### DIFF
--- a/src/Quantum/Quantum.jl
+++ b/src/Quantum/Quantum.jl
@@ -129,7 +129,7 @@ function Base.hcat(A::TensorNetwork{QA}, B::TensorNetwork{QB}) where {QA<:Quantu
     for site in sites(B)
         a = labels(A, :plug, site)
         b = labels(B, :plug, site)
-        if a != b
+        if a != b && a ∉ labels(B)
             replace!(B, b => a)
         end
     end

--- a/test/MatrixProductOperator_test.jl
+++ b/test/MatrixProductOperator_test.jl
@@ -159,6 +159,11 @@
         end
     end
 
+    @testset "norm" begin
+        mpo = rand(MatrixProduct{Operator,Open}, n = 8, p = 2, χ = 8)
+        @test norm(mpo) ≈ 1
+    end
+
     # @testset "Initialization" begin
     #     for params in [
     #         (2, 2, 2, 1),

--- a/test/MatrixProductState_test.jl
+++ b/test/MatrixProductState_test.jl
@@ -145,4 +145,9 @@
             hcat(mps, mps) isa TensorNetwork{<:Composite}
         end
     end
+
+    @testset "norm" begin
+        mps = rand(MatrixProduct{State,Open}, n = 8, p = 2, χ = 8)
+        @test norm(mps) ≈ 1
+    end
 end


### PR DESCRIPTION
This pull request addresses the issue encountered (resolves #64) when computing the `norm` of a Matrix Product Operator (MPO).

The problem arises when the function attempts to replace a tensor label in a tensor network with a new one that already exists. This scenario often occurs with MPOs and other tensor structures with multiple `interlayer` connections, as the `plug` `labels` might not be in the same order in the state and its adjoint.

This error was not encountered with Matrix Product States (MPS) because they have a single `interlayer` that matches their adjoint.

In this PR we have corrected this error and we also have introduced tests to validate the `norm` function for both MPS and MPO.