### PR TITLE
Implement `ProjectedEntangledPair` ansatz

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -29,6 +29,7 @@ makedocs(
         "Quantum Tensor Networks"=>[
             "Introduction" => "quantum/index.md",
             "Matrix Product States (MPS)" => "quantum/mps.md",
+            "Projected Entangled Pair States (PEPS)" => "quantum/peps.md",
         ],
         "Examples"=>[
             "Google's Quantum Advantage experiment" => "examples/google-rqc.md",

--- a/docs/src/quantum/peps.md
+++ b/docs/src/quantum/peps.md
@@ -28,6 +28,8 @@ Label(fig[1,2, Bottom()], "Periodic") # hide
 fig # hide
 ```
 
+## Projected Entangled Pair Operators (PEPO)
+
 ```@example viz
 fig = Figure() # hide
 
@@ -42,8 +44,6 @@ Label(fig[1,2, Bottom()], "Periodic") # hide
 
 fig # hide
 ```
-
-## Projected Entangled Pair Operators (PEPO)
 
 ```@docs
 ProjectedEntangledPair

--- a/docs/src/quantum/peps.md
+++ b/docs/src/quantum/peps.md
@@ -1,0 +1,51 @@
+# Projected Entangled Pair States (PEPS)
+
+Projected Entangled Pair States (PEPS) are a Quantum Tensor Network ansatz whose tensors are laid out in a 2D lattice. Depending on the boundary conditions, the chains can be open or closed (i.e. periodic boundary conditions).
+
+```@setup viz
+using Makie
+Makie.inline!(true)
+set_theme!(resolution=(800,400))
+
+using CairoMakie
+
+using Tenet
+using NetworkLayout
+```
+
+```@example viz
+fig = Figure() # hide
+
+tn_open = rand(PEPS{Open}, rows=10, cols=10, χ=4) # hide
+tn_periodic = rand(PEPS{Periodic}, rows=10, cols=10, χ=4) # hide
+
+plot!(fig[1,1], tn_open, layout=Stress(seed=1)) # hide
+plot!(fig[1,2], tn_periodic, layout=Stress(seed=10,dim=2,iterations=100000)) # hide
+
+Label(fig[1,1, Bottom()], "Open") # hide
+Label(fig[1,2, Bottom()], "Periodic") # hide
+
+fig # hide
+```
+
+```@example viz
+fig = Figure() # hide
+
+tn_open = rand(PEPO{Open}, rows=10, cols=10, χ=4) # hide
+tn_periodic = rand(PEPO{Periodic}, rows=10, cols=10, χ=4) # hide
+
+plot!(fig[1,1], tn_open, layout=Stress(seed=1)) # hide
+plot!(fig[1,2], tn_periodic, layout=Stress(seed=10,dim=2,iterations=100000)) # hide
+
+Label(fig[1,1, Bottom()], "Open") # hide
+Label(fig[1,2, Bottom()], "Periodic") # hide
+
+fig # hide
+```
+
+## Projected Entangled Pair Operators (PEPO)
+
+```@docs
+ProjectedEntangledPair
+ProjectedEntangledPair(::Any)
+```

--- a/src/Quantum/PEP.jl
+++ b/src/Quantum/PEP.jl
@@ -51,31 +51,34 @@ function ProjectedEntangledPair{P,B}(
     )
 
     m, n = size(arrays)
-    hinds = Dict((i, j) => Symbol(uuid4()) for i in 1:m for j in ringpeek(1:n))
-    vinds = Dict((i, j) => Symbol(uuid4()) for i in ringpeek(1:m) for j in 1:n)
-    oinds = Dict((i, j) => Symbol(uuid4()) for i in 1:m for j in 1:n)
-    iinds = Dict((i, j) => Symbol(uuid4()) for i in 1:m for j in 1:n)
+    hinds = Dict((i, j) => Symbol(uuid4()) for i in 1:m, j in ringpeek(1:n))
+    vinds = Dict((i, j) => Symbol(uuid4()) for i in ringpeek(1:m), j in 1:n)
+    oinds = Dict((i, j) => Symbol(uuid4()) for i in 1:m, j in 1:n)
+    iinds = Dict((i, j) => Symbol(uuid4()) for i in 1:m, j in 1:n)
 
     interlayer = if P <: State
-        [Bijection(oinds)]
+        [Bijection(Dict(i + j * m => index for ((i, j), index) in oinds))]
     elseif P <: Operator
-        [Bijection(iinds), Bijection(oinds)]
+        [
+            Bijection(Dict(i + j * m => index for ((i, j), index) in iinds)),
+            Bijection(Dict(i + j * m => index for ((i, j), index) in oinds)),
+        ]
     else
         throw(ErrorException("Plug $P is not valid"))
     end
 
-    tensors = map(zip(Iterators.map(Tuple, eachindex(arrays)), arrays)) do ((i, j), array)
+    tensors = map(zip(Iterators.map(Tuple, eachindex(IndexCartesian(), arrays)), arrays)) do ((i, j), array)
         dirs = _sitealias(ProjectedEntangledPair{P,B}, order, (m, n), (i, j))
 
         labels = map(dirs) do dir
             if dir === :l
-                hinds[((mod1(i - 1, n), i), j)]
+                hinds[(i, (mod1(j - 1, n), j))]
             elseif dir === :r
-                hinds[((i, mod1(i + 1, n)), j)]
+                hinds[(i, (j, mod1(j + 1, n)))]
             elseif dir === :u
-                vinds[(i, (mod1(j - 1, n), j))]
+                vinds[((mod1(i - 1, n), i), j)]
             elseif dir === :d
-                vinds[(i, (j, mod1(j + 1, n)))]
+                vinds[((i, mod1(i + 1, n)), j)]
             elseif dir === :i
                 iinds[(i, j)]
             elseif dir === :o
@@ -85,7 +88,7 @@ function ProjectedEntangledPair{P,B}(
         alias = Dict(dir => label for (dir, label) in zip(dirs, labels))
 
         Tensor(array, labels; alias = alias)
-    end
+    end |> vec
 
     return TensorNetwork{ProjectedEntangledPair{P,B}}(tensors; χ, plug = P, interlayer, metadata...)
 end

--- a/src/Quantum/PEP.jl
+++ b/src/Quantum/PEP.jl
@@ -1,5 +1,15 @@
 using UUIDs: uuid4
 
+"""
+    ProjectedEntangledPair{P<:Plug,B<:Boundary} <: Quantum
+
+A generic ansatz representing Projected Entangled Pair States (PEPS) and Projected Entangled Pair Operators (PEPO).
+Type variable `P` represents the `Plug` type (`State` or `Operator`) and `B` represents the `Boundary` type (`Open` or `Periodic`).
+
+# Ansatz Fields
+
+  - `χ::Union{Nothing,Int}` Maximum virtual bond dimension.
+"""
 abstract type ProjectedEntangledPair{P,B} <: Quantum where {P<:Plug,B<:Boundary} end
 
 boundary(::Type{<:ProjectedEntangledPair{P,B}}) where {P,B} = B
@@ -38,6 +48,16 @@ _sitealias(::Type{ProjectedEntangledPair{P,Periodic}}, order, _, _) where {P<:Pl
 defaultorder(::Type{ProjectedEntangledPair{State}}) = (:l, :r, :u, :d, :o)
 defaultorder(::Type{ProjectedEntangledPair{Operator}}) = (:l, :r, :u, :d, :i, :o)
 
+"""
+    ProjectedEntangledPair{P,B}(arrays::Matrix{AbstractArray}; χ::Union{Nothing,Int} = nothing, order = defaultorder(ProjectedEntangledPair{P}))
+
+Construct a [`TensorNetwork`](@ref) with [`ProjectedEntangledPair`](@ref) ansatz, from the arrays of the tensors.
+
+# Keyword Arguments
+
+  - `χ` Maximum virtual bond dimension. Defaults to `nothing`.
+  - `order` Order of the tensor indices on `arrays`. Defaults to `(:l, :r, :u, :d, :o)` if `P` is a `State`, `(:l, :r, :u, :d, :i, :o)` if `Operator`.
+"""
 function ProjectedEntangledPair{P,B}(
     arrays;
     χ = nothing,

--- a/src/Quantum/PEP.jl
+++ b/src/Quantum/PEP.jl
@@ -155,7 +155,7 @@ function Base.rand(rng::Random.AbstractRNG, sampler::TNSampler{ProjectedEntangle
     # normalize state
     arrays[1, 1] ./= P <: State ? sqrt(p) : p
 
-    ProjectedEntangledPair{State,Open}(arrays; χ)
+    ProjectedEntangledPair{P,Open}(arrays; χ)
 end
 
 # TODO normalize
@@ -188,5 +188,5 @@ function Base.rand(rng::Random.AbstractRNG, sampler::TNSampler{ProjectedEntangle
     # normalize state
     arrays[1, 1] ./= P <: State ? sqrt(p) : p
 
-    ProjectedEntangledPair{State,Periodic}(arrays; χ)
+    ProjectedEntangledPair{P,Periodic}(arrays; χ)
 end

--- a/src/Quantum/PEP.jl
+++ b/src/Quantum/PEP.jl
@@ -92,3 +92,7 @@ function ProjectedEntangledPair{P,B}(
 
     return TensorNetwork{ProjectedEntangledPair{P,B}}(tensors; χ, plug = P, interlayer, metadata...)
 end
+
+const PEPS = ProjectedEntangledPair{State}
+const PEPO = ProjectedEntangledPair{Operator}
+

--- a/src/Quantum/PEP.jl
+++ b/src/Quantum/PEP.jl
@@ -9,8 +9,18 @@ function ProjectedEntangledPair{P}(arrays; boundary::Type{<:Boundary} = Open, kw
     ProjectedEntangledPair{P,boundary}(arrays; kwargs...)
 end
 
+metadata(T::Type{<:ProjectedEntangledPair}) = merge(metadata(supertype(T)), @NamedTuple begin
+    χ::Union{Nothing,Int}
+end)
+
 function checkmeta(::Type{ProjectedEntangledPair{P,B}}, tn::TensorNetwork) where {P,B}
-    # TODO
+    # meta has correct value
+    isnothing(tn.χ) || tn.χ > 0 || return false
+
+    # no virtual index has dimensionality bigger than χ
+    all(i -> isnothing(tn.χ) || size(tn, i) <= tn.χ, labels(tn, :virtual)) || return false
+
+    return true
 end
 
 function _sitealias(::Type{ProjectedEntangledPair{P,Open}}, order, size, pos) where {P<:Plug}

--- a/src/Quantum/PEP.jl
+++ b/src/Quantum/PEP.jl
@@ -1,0 +1,76 @@
+using UUIDs: uuid4
+
+abstract type ProjectedEntangledPair{P,B} <: Quantum where {P<:Plug,B<:Boundary} end
+
+boundary(::Type{<:ProjectedEntangledPair{P,B}}) where {P,B} = B
+plug(::Type{<:ProjectedEntangledPair{P}}) where {P} = P
+
+function ProjectedEntangledPair{P}(arrays; boundary::Type{<:Boundary} = Open, kwargs...) where {P<:Plug}
+    ProjectedEntangledPair{P,boundary}(arrays; kwargs...)
+end
+
+function checkmeta(::Type{ProjectedEntangledPair{P,B}}, tn::TensorNetwork) where {P,B}
+    # TODO
+end
+
+function _sitealias(::Type{ProjectedEntangledPair{P,Open}}, order, size, pos) where {P<:Plug}
+    m, n = size
+    i, j = pos
+
+    order = [order...]
+
+    filter(order) do dir
+        !(i == 1 && dir === :u || i == m && dir === :d || j == 1 && dir === :l || j == n && dir === :r)
+    end
+end
+_sitealias(::Type{ProjectedEntangledPair{P,Periodic}}, order, _, _) where {P<:Plug} = tuple(order...)
+
+defaultorder(::Type{ProjectedEntangledPair{State}}) = (:l, :r, :u, :d, :o)
+defaultorder(::Type{ProjectedEntangledPair{Operator}}) = (:l, :r, :u, :d, :i, :o)
+
+function ProjectedEntangledPair{P,B}(
+    arrays::Matrix;
+    order = defaultorder(ProjectedEntangledPair{P}),
+    metadata...,
+) where {P<:Plug,B<:Boundary}
+    issetequal(order, defaultorder(ProjectedEntangledPair{P})) || throw(
+        ArgumentError(
+            "`order` must be a permutation of $(join(String.(defaultorder(ProjectedEntangledPair{P})), ',', " and "))",
+        ),
+    )
+
+    m, n = size(arrays)
+    hinds = Dict((i, j) => Symbol(uuid4()) for i in 1:m for j in ringpeek(1:n))
+    vinds = Dict((i, j) => Symbol(uuid4()) for i in ringpeek(1:m) for j in 1:n)
+    oinds = Dict((i, j) => Symbol(uuid4()) for i in 1:m for j in 1:n)
+    iinds = Dict((i, j) => Symbol(uuid4()) for i in 1:m for j in 1:n)
+
+    # mark plug connectors
+    plug = Dict((site, :out) => label for (site, label) in oinds)
+    # TODO mark input plugs
+
+    tensors = map(zip(Iterators.map(Tuple, eachindex(arrays)), arrays)) do ((i, j), array)
+        dirs = _sitealias(ProjectedEntangledPair{P,B}, order, (m, n), (i, j))
+
+        labels = map(dirs) do dir
+            if dir === :l
+                hinds[((mod1(i - 1, n), i), j)]
+            elseif dir === :r
+                hinds[((i, mod1(i + 1, n)), j)]
+            elseif dir === :u
+                vinds[(i, (mod1(j - 1, n), j))]
+            elseif dir === :d
+                vinds[(i, (j, mod1(j + 1, n)))]
+            elseif dir === :i
+                iinds[(i, j)]
+            elseif dir === :o
+                oinds[(i, j)]
+            end
+        end
+        alias = Dict(dir => label for (dir, label) in zip(dirs, labels))
+
+        Tensor(array, labels; alias = alias)
+    end
+
+    return TensorNetwork{ProjectedEntangledPair{P,B}}(tensors; plug, metadata...)
+end

--- a/src/Quantum/Quantum.jl
+++ b/src/Quantum/Quantum.jl
@@ -305,3 +305,4 @@ function marginal(ψ, site)
 end
 
 include("MP.jl")
+include("PEP.jl")

--- a/src/Tenet.jl
+++ b/src/Tenet.jl
@@ -22,6 +22,7 @@ export Plug, plug, Property, State, Operator
 export sites, fidelity
 
 export MatrixProduct
+export ProjectedEntangledPair, PEPS, PEPO
 
 if !isdefined(Base, :get_extension)
     using Requires

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -357,14 +357,17 @@ function Base.view(tn::TensorNetwork, slices::Pair{Symbol,<:Any}...)
         slice!(tn, label, i)
     end
 
+    i isa Integer && delete!(tn.indices, label)
+
     return tn
 end
 
+Base.selectdim(tn::TensorNetwork, label::Symbol, i) = @view tn[label=>i]
 function Base.view(tn::TensorNetwork, slices::Pair{Symbol,<:Any}...)
     tn = copy(tn)
 
     for (label, i) in slices
-        selectdim!(tn, label, i)
+        slice!(tn, label, i)
     end
 
     return tn

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -357,19 +357,6 @@ function Base.view(tn::TensorNetwork, slices::Pair{Symbol,<:Any}...)
         slice!(tn, label, i)
     end
 
-    i isa Integer && delete!(tn.indices, label)
-
-    return tn
-end
-
-Base.selectdim(tn::TensorNetwork, label::Symbol, i) = @view tn[label=>i]
-function Base.view(tn::TensorNetwork, slices::Pair{Symbol,<:Any}...)
-    tn = copy(tn)
-
-    for (label, i) in slices
-        slice!(tn, label, i)
-    end
-
     return tn
 end
 

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -360,6 +360,16 @@ function Base.view(tn::TensorNetwork, slices::Pair{Symbol,<:Any}...)
     return tn
 end
 
+function Base.view(tn::TensorNetwork, slices::Pair{Symbol,<:Any}...)
+    tn = copy(tn)
+
+    for (label, i) in slices
+        selectdim!(tn, label, i)
+    end
+
+    return tn
+end
+
 """
     rand(TensorNetwork, n::Integer, regularity::Integer; out = 0, dim = 2:9, seed = nothing, globalind = false)
 


### PR DESCRIPTION
This PR closes #8. It implements an initial version of the `ProjectedEntangledPair` ansatz.
There are some things to do yet, like normalized random initialization, contraction or tests. But I would like to merge this now so we have more ansatzs than MPS to test functionalities.