### PR TITLE
Fix `tensors` function for `Operator` type

### DIFF
--- a/src/Quantum/Quantum.jl
+++ b/src/Quantum/Quantum.jl
@@ -81,7 +81,7 @@ Return the `Tensor` connected to the [`TensorNetwork`](@ref) on `site`.
 See also: [`sites`](@ref).
 """
 tensors(tn::TensorNetwork{<:Quantum}, site::Integer, args...) = tensors(plug(tn), tn, site, args...)
-tensors(::Type{State}, tn::TensorNetwork{<:Quantum}, site) = select(tn, labels(tn, :plug, site)) |> only
+tensors(::Union{Type{Operator}, Type{State}}, tn::TensorNetwork{<:Quantum}, site) = select(tn, labels(tn, :plug, site)) |> only
 @valsplit 4 tensors(T::Type{Operator}, tn::TensorNetwork{<:Quantum}, site, dir::Symbol) =
     throw(MethodError(sites, "dir=$dir not recognized"))
 

--- a/test/MatrixProductOperator_test.jl
+++ b/test/MatrixProductOperator_test.jl
@@ -76,6 +76,14 @@
                           only(select(ψ, last(ψ.interlayer)[3])).meta[:alias][:l]
                 end
             end
+
+            @testset "tensors" begin
+                arrays = [rand(1, 2, 2), rand(1, 1, 2, 2), rand(1, 2, 2)]
+                ψ = MatrixProduct{Operator,Open}(arrays, order = (:l, :r, :i, :o))
+
+                @test tensors(ψ, 1) isa Tensor
+                @test size(tensors(ψ)) |> first == length(ψ) == 3
+            end
         end
 
         @testset "`Periodic` boundary" begin
@@ -130,6 +138,14 @@
                           only(select(ψ, first(ψ.interlayer)[3])).meta[:alias][:l]
                     @test only(select(ψ, first(ψ.interlayer)[3])).meta[:alias][:r] ===
                           only(select(ψ, first(ψ.interlayer)[1])).meta[:alias][:l]
+                end
+
+                @testset "tensors" begin
+                    arrays = [rand(1, 1, 2, 2), rand(1, 1, 2, 2), rand(1, 1, 2, 2)]
+                    ψ = MatrixProduct{Operator,Periodic}(arrays, order = (:l, :r, :i, :o))
+
+                    @test tensors(ψ, 1) isa Tensor
+                    @test size(tensors(ψ)) |> first == length(ψ) == 3
                 end
             end
         end

--- a/test/MatrixProductState_test.jl
+++ b/test/MatrixProductState_test.jl
@@ -80,6 +80,14 @@
                     @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
                     @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
                 end
+
+                @testset "tensors" begin
+                    arrays = [rand(1, 2), rand(1, 1, 2), rand(1, 2)]
+                    ψ = MatrixProduct{State,Open}(arrays, order = (:l, :r, :o))
+
+                    @test tensors(ψ, 1) isa Tensor
+                    @test size(tensors(ψ)) |> first == length(ψ) == 3
+                end
             end
         end
 
@@ -127,6 +135,14 @@
                     @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
                     @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
                     @test tensors(ψ, 3).meta[:alias][:r] === tensors(ψ, 1).meta[:alias][:l]
+                end
+
+                @testset "tensors" begin
+                    arrays = [rand(1, 1, 2), rand(1, 1, 2), rand(1, 1, 2)]
+                    ψ = MatrixProduct{State,Periodic}(arrays, order = (:l, :r, :o))
+
+                    @test tensors(ψ, 1) isa Tensor
+                    @test size(tensors(ψ)) |> first == length(ψ) == 3
                 end
             end
         end


### PR DESCRIPTION
### Summary
This PR addresses a bug in the `tensors` function which caused a `MethodError` when called with a `TensorNetwork` of `Operator` type. The root cause was that the function signature was designed exclusively for the `State` type. The solution was to extend the function signature to handle both `Operator` and `State` types.

In addition to the fix, this PR introduces new tests designed to cover this scenario and prevent regressions.

### Example
Here we can see an example of the previous error:
```julia
julia> _arrays = [rand(1, 1, 2, 2), rand(1, 1, 2, 2), rand(1, 1, 2, 2)]
3-element Vector{Array{Float64, 4}}:
 [0.5446558537456561;;; 0.43215020981519403;;;; 0.032683161122349036;;; 0.6659303187609796]
 [0.08054317169533542;;; 0.48062834256926257;;;; 0.28742074946598595;;; 0.17849508460251406]
 [0.7073563711310278;;; 0.12764406681391194;;;; 0.34387035001349886;;; 0.8791235663956318]

julia> ψ = MatrixProduct{Operator,Periodic}(_arrays, order = (:l, :r, :i, :o))
TensorNetwork{MatrixProduct{Operator, Periodic}, NamedTuple{(:plug, :interlayer, :χ), Tuple{Type{<:Plug}, Vector{Bijections.Bijection{Int64, Symbol}}, Union{Nothing, Int64}}}}(#tensors=3, #labels=9)

julia> tensors(ψ, 1)
ERROR: MethodError: no method matching tensors(::Type{Operator}, ::TensorNetwork{MatrixProduct{Operator, Periodic}, NamedTuple{(:plug, :interlayer, :χ), Tuple{Type{<:Plug}, Vector{Bijections.Bijection{Int64, Symbol}}, Union{Nothing, Int64}}}}, ::Int64)

Closest candidates are:
  tensors(::Type{Operator}, ::TensorNetwork{<:Quantum}, ::Any, ::Symbol)
   @ Tenet ~/.julia/packages/ValSplit/MMCz3/src/ValSplit.jl:141
  tensors(::Type{State}, ::TensorNetwork{<:Quantum}, ::Any)
   @ Tenet ~/git/Tenet.jl/src/Quantum/Quantum.jl:84
  tensors(::TensorNetwork{<:Quantum}, ::Integer, ::Any...)
   @ Tenet ~/git/Tenet.jl/src/Quantum/Quantum.jl:83

Stacktrace:
 [1] tensors(::TensorNetwork{MatrixProduct{Operator, Periodic}, NamedTuple{(:plug, :interlayer, :χ), Tuple{Type{<:Plug}, Vector{Bijections.Bijection{Int64, Symbol}}, Union{Nothing, Int64}}}}, ::Int64)
   @ Tenet ~/git/Tenet.jl/src/Quantum/Quantum.jl:83
 [2] top-level scope
   @ REPL[9]:1
```