### PR TITLE
Implement `Infinite` `Boundary` Conditions for `MatrixProduct` and `ProjectedEntangledPair` Types

### DIFF
--- a/src/Quantum/MP.jl
+++ b/src/Quantum/MP.jl
@@ -46,6 +46,7 @@ _sitealias(::Type{MatrixProduct{P,Open}}, order, n, i) where {P<:Plug} =
         order
     end
 _sitealias(::Type{MatrixProduct{P,Periodic}}, order, n, i) where {P<:Plug} = tuple(order...)
+_sitealias(::Type{MatrixProduct{P,Infinite}}, order, n, i) where {P<:Plug} = tuple(order...)
 
 defaultorder(::Type{MatrixProduct{State}}) = (:l, :r, :o)
 defaultorder(::Type{MatrixProduct{Operator}}) = (:l, :r, :i, :o)
@@ -109,6 +110,17 @@ end
 
 const MPS = MatrixProduct{State}
 const MPO = MatrixProduct{Operator}
+
+tensors(ψ::TensorNetwork{MatrixProduct{P,Infinite}}, args...) where {P<:Plug} =
+    throw(ArgumentError("You need to specify the site for an infinite MatrixProduct$P"))
+
+tensors(ψ::TensorNetwork{MatrixProduct{P,Infinite}}, site::Int, args...) where {P<:Plug} =
+    tensors(plug(ψ), ψ, mod(site, length(ψ)) + 1, args...)
+
+Base.show(io::IO, ψ::TensorNetwork{MatrixProduct{P,Infinite}}) where {P<:Plug} =
+    print(io, "$(typeof(ψ))(#tensors=∞, #labels=∞)")
+
+Base.length(ψ::TensorNetwork{MatrixProduct{P,Infinite}}) where {P<:Plug} = Inf
 
 # NOTE does not use optimal contraction path, but "parallel-optimal" which costs x2 more
 # function contractpath(a::TensorNetwork{<:MatrixProductState}, b::TensorNetwork{<:MatrixProductState})

--- a/src/Quantum/MP.jl
+++ b/src/Quantum/MP.jl
@@ -112,7 +112,7 @@ const MPS = MatrixProduct{State}
 const MPO = MatrixProduct{Operator}
 
 tensors(ψ::TensorNetwork{MatrixProduct{P,Infinite}}, args...) where {P<:Plug} =
-    throw(ArgumentError("You need to specify the site for an infinite MatrixProduct$P"))
+    throw(MethodError("You need to specify the site for an infinite MatrixProduct$P"))
 
 tensors(ψ::TensorNetwork{MatrixProduct{P,Infinite}}, site::Int, args...) where {P<:Plug} =
     tensors(plug(ψ), ψ, mod1(site, length(ψ.tensors)), args...)

--- a/src/Quantum/MP.jl
+++ b/src/Quantum/MP.jl
@@ -115,7 +115,7 @@ tensors(ψ::TensorNetwork{MatrixProduct{P,Infinite}}, args...) where {P<:Plug} =
     throw(ArgumentError("You need to specify the site for an infinite MatrixProduct$P"))
 
 tensors(ψ::TensorNetwork{MatrixProduct{P,Infinite}}, site::Int, args...) where {P<:Plug} =
-    tensors(plug(ψ), ψ, mod(site, length(ψ)) + 1, args...)
+    tensors(plug(ψ), ψ, mod1(site, length(ψ.tensors)), args...)
 
 Base.show(io::IO, ψ::TensorNetwork{MatrixProduct{P,Infinite}}) where {P<:Plug} =
     print(io, "$(typeof(ψ))(#tensors=∞, #labels=∞)")

--- a/src/Quantum/MP.jl
+++ b/src/Quantum/MP.jl
@@ -111,14 +111,8 @@ end
 const MPS = MatrixProduct{State}
 const MPO = MatrixProduct{Operator}
 
-tensors(ψ::TensorNetwork{MatrixProduct{P,Infinite}}, args...) where {P<:Plug} =
-    throw(MethodError("You need to specify the site for an infinite MatrixProduct$P"))
-
 tensors(ψ::TensorNetwork{MatrixProduct{P,Infinite}}, site::Int, args...) where {P<:Plug} =
     tensors(plug(ψ), ψ, mod1(site, length(ψ.tensors)), args...)
-
-Base.show(io::IO, ψ::TensorNetwork{MatrixProduct{P,Infinite}}) where {P<:Plug} =
-    print(io, "$(typeof(ψ))(#tensors=∞, #labels=∞)")
 
 Base.length(ψ::TensorNetwork{MatrixProduct{P,Infinite}}) where {P<:Plug} = Inf
 

--- a/src/Quantum/PEP.jl
+++ b/src/Quantum/PEP.jl
@@ -121,7 +121,7 @@ tensors(ψ::TensorNetwork{ProjectedEntangledPair{P,Infinite}}, args...) where {P
     throw(ArgumentError("You need to specify the site for an infinite MatrixProduct$P"))
 
 tensors(ψ::TensorNetwork{ProjectedEntangledPair{P,Infinite}}, site::Int, args...) where {P<:Plug} =
-    tensors(plug(ψ), ψ, mod(site, length(ψ)) + 1, args...)
+    tensors(plug(ψ), ψ, mod1(site, length(ψ.tensors)), args...)
 
 Base.show(io::IO, ψ::TensorNetwork{ProjectedEntangledPair{P,Infinite}}) where {P<:Plug} =
     print(io, "$(typeof(ψ))(#tensors=∞, #labels=∞)")

--- a/src/Quantum/PEP.jl
+++ b/src/Quantum/PEP.jl
@@ -118,7 +118,7 @@ const PEPS = ProjectedEntangledPair{State}
 const PEPO = ProjectedEntangledPair{Operator}
 
 tensors(ψ::TensorNetwork{ProjectedEntangledPair{P,Infinite}}, args...) where {P<:Plug} =
-    throw(ArgumentError("You need to specify the site for an infinite MatrixProduct$P"))
+    throw(MethodError("You need to specify the site for an infinite MatrixProduct$P"))
 
 tensors(ψ::TensorNetwork{ProjectedEntangledPair{P,Infinite}}, site::Int, args...) where {P<:Plug} =
     tensors(plug(ψ), ψ, mod1(site, length(ψ.tensors)), args...)

--- a/src/Quantum/PEP.jl
+++ b/src/Quantum/PEP.jl
@@ -117,14 +117,8 @@ end
 const PEPS = ProjectedEntangledPair{State}
 const PEPO = ProjectedEntangledPair{Operator}
 
-tensors(ψ::TensorNetwork{ProjectedEntangledPair{P,Infinite}}, args...) where {P<:Plug} =
-    throw(MethodError("You need to specify the site for an infinite MatrixProduct$P"))
-
 tensors(ψ::TensorNetwork{ProjectedEntangledPair{P,Infinite}}, site::Int, args...) where {P<:Plug} =
     tensors(plug(ψ), ψ, mod1(site, length(ψ.tensors)), args...)
-
-Base.show(io::IO, ψ::TensorNetwork{ProjectedEntangledPair{P,Infinite}}) where {P<:Plug} =
-    print(io, "$(typeof(ψ))(#tensors=∞, #labels=∞)")
 
 Base.length(ψ::TensorNetwork{ProjectedEntangledPair{P,Infinite}}) where {P<:Plug} = Inf
 

--- a/src/Quantum/PEP.jl
+++ b/src/Quantum/PEP.jl
@@ -44,6 +44,7 @@ function _sitealias(::Type{ProjectedEntangledPair{P,Open}}, order, size, pos) wh
     end
 end
 _sitealias(::Type{ProjectedEntangledPair{P,Periodic}}, order, _, _) where {P<:Plug} = tuple(order...)
+_sitealias(::Type{ProjectedEntangledPair{P,Infinite}}, order, _, _) where {P<:Plug} = tuple(order...)
 
 defaultorder(::Type{ProjectedEntangledPair{State}}) = (:l, :r, :u, :d, :o)
 defaultorder(::Type{ProjectedEntangledPair{Operator}}) = (:l, :r, :u, :d, :i, :o)
@@ -115,6 +116,17 @@ end
 
 const PEPS = ProjectedEntangledPair{State}
 const PEPO = ProjectedEntangledPair{Operator}
+
+tensors(ψ::TensorNetwork{ProjectedEntangledPair{P,Infinite}}, args...) where {P<:Plug} =
+    throw(ArgumentError("You need to specify the site for an infinite MatrixProduct$P"))
+
+tensors(ψ::TensorNetwork{ProjectedEntangledPair{P,Infinite}}, site::Int, args...) where {P<:Plug} =
+    tensors(plug(ψ), ψ, mod(site, length(ψ)) + 1, args...)
+
+Base.show(io::IO, ψ::TensorNetwork{ProjectedEntangledPair{P,Infinite}}) where {P<:Plug} =
+    print(io, "$(typeof(ψ))(#tensors=∞, #labels=∞)")
+
+Base.length(ψ::TensorNetwork{ProjectedEntangledPair{P,Infinite}}) where {P<:Plug} = Inf
 
 # TODO normalize
 # TODO let choose the orthogonality center

--- a/src/Quantum/Quantum.jl
+++ b/src/Quantum/Quantum.jl
@@ -29,6 +29,7 @@ end
 abstract type Boundary end
 abstract type Open <: Boundary end
 abstract type Periodic <: Boundary end
+abstract type Infinite <: Boundary end
 
 """
     boundary(::TensorNetwork)
@@ -38,6 +39,7 @@ Return the `Boundary` type of the [`TensorNetwork`](@ref). The following `Bounda
 
   - `Open`
   - `Periodic`
+  - `Infinite`
 """
 function boundary end
 boundary(::T) where {T<:TensorNetwork} = boundary(T)

--- a/src/Quantum/Quantum.jl
+++ b/src/Quantum/Quantum.jl
@@ -83,7 +83,7 @@ Return the `Tensor` connected to the [`TensorNetwork`](@ref) on `site`.
 See also: [`sites`](@ref).
 """
 tensors(tn::TensorNetwork{<:Quantum}, site::Integer, args...) = tensors(plug(tn), tn, site, args...)
-tensors(::Union{Type{Operator}, Type{State}}, tn::TensorNetwork{<:Quantum}, site) = select(tn, labels(tn, :plug, site)) |> only
+tensors(::Type{State}, tn::TensorNetwork{<:Quantum}, site) = select(tn, labels(tn, :plug, site)) |> only
 @valsplit 4 tensors(T::Type{Operator}, tn::TensorNetwork{<:Quantum}, site, dir::Symbol) =
     throw(MethodError(sites, "dir=$dir not recognized"))
 

--- a/src/Quantum/Quantum.jl
+++ b/src/Quantum/Quantum.jl
@@ -83,7 +83,7 @@ Return the `Tensor` connected to the [`TensorNetwork`](@ref) on `site`.
 See also: [`sites`](@ref).
 """
 tensors(tn::TensorNetwork{<:Quantum}, site::Integer, args...) = tensors(plug(tn), tn, site, args...)
-tensors(::Type{State}, tn::TensorNetwork{<:Quantum}, site) = select(tn, labels(tn, :plug, site)) |> only
+tensors(::Union{Type{Operator}, Type{State}}, tn::TensorNetwork{<:Quantum}, site) = select(tn, labels(tn, :plug, site)) |> only
 @valsplit 4 tensors(T::Type{Operator}, tn::TensorNetwork{<:Quantum}, site, dir::Symbol) =
     throw(MethodError(sites, "dir=$dir not recognized"))
 

--- a/src/Tenet.jl
+++ b/src/Tenet.jl
@@ -14,7 +14,7 @@ export transform, transform!
 
 include("Quantum/Quantum.jl")
 export Quantum
-export Boundary, boundary, Open, Periodic
+export Boundary, boundary, Open, Periodic, Infinite
 export Plug, plug, Property, State, Operator
 export sites, fidelity
 

--- a/test/MatrixProductOperator_test.jl
+++ b/test/MatrixProductOperator_test.jl
@@ -192,10 +192,7 @@
                     arrays = [rand(1, 1, 2, 2), rand(1, 1, 2, 2), rand(1, 1, 2, 2)]
                     ψ = MatrixProduct{Operator,Infinite}(arrays, order = (:l, :r, :i, :o))
 
-                    @test tensors(ψ, 1) isa Tensor
                     @test length(ψ) == Inf
-                    @test tensors(ψ, 4) == tensors(ψ, 1)
-                    @test tensors(ψ, 0) == tensors(ψ, 3)
                 end
             end
         end

--- a/test/MatrixProductOperator_test.jl
+++ b/test/MatrixProductOperator_test.jl
@@ -76,14 +76,6 @@
                           only(select(ψ, last(ψ.interlayer)[3])).meta[:alias][:l]
                 end
             end
-
-            @testset "tensors" begin
-                arrays = [rand(1, 2, 2), rand(1, 1, 2, 2), rand(1, 2, 2)]
-                ψ = MatrixProduct{Operator,Open}(arrays, order = (:l, :r, :i, :o))
-
-                @test tensors(ψ, 1) isa Tensor
-                @test size(tensors(ψ)) |> first == length(ψ) == 3
-            end
         end
 
         @testset "`Periodic` boundary" begin
@@ -138,14 +130,6 @@
                           only(select(ψ, first(ψ.interlayer)[3])).meta[:alias][:l]
                     @test only(select(ψ, first(ψ.interlayer)[3])).meta[:alias][:r] ===
                           only(select(ψ, first(ψ.interlayer)[1])).meta[:alias][:l]
-                end
-
-                @testset "tensors" begin
-                    arrays = [rand(1, 1, 2, 2), rand(1, 1, 2, 2), rand(1, 1, 2, 2)]
-                    ψ = MatrixProduct{Operator,Periodic}(arrays, order = (:l, :r, :i, :o))
-
-                    @test tensors(ψ, 1) isa Tensor
-                    @test size(tensors(ψ)) |> first == length(ψ) == 3
                 end
             end
         end

--- a/test/MatrixProductOperator_test.jl
+++ b/test/MatrixProductOperator_test.jl
@@ -186,16 +186,6 @@
                 MatrixProduct{Operator,Infinite}(arrays) isa TensorNetwork{MatrixProduct{Operator,Infinite}}
             end
 
-            @testset "tensors" begin
-                arrays = [rand(1, 1, 2, 2), rand(1, 1, 2, 2), rand(1, 1, 2, 2)]
-                ψ = MatrixProduct{Operator,Infinite}(arrays, order = (:l, :r, :i, :o))
-
-                @test_throws ArgumentError tensors(ψ)
-                @test tensors(ψ, 1) == tensors(ψ, 4)
-                @test tensors(ψ, -1) == tensors(ψ, 3)
-                @test length(ψ) == Inf
-            end
-
             @testset "metadata" begin
                 @testset "alias" begin
                     arrays = [rand(1, 1, 2, 2), rand(1, 1, 2, 2), rand(1, 1, 2, 2)]
@@ -212,6 +202,16 @@
                           only(select(ψ, first(ψ.interlayer)[3])).meta[:alias][:l]
                     @test only(select(ψ, first(ψ.interlayer)[3])).meta[:alias][:r] ===
                           only(select(ψ, first(ψ.interlayer)[1])).meta[:alias][:l]
+                end
+
+                @testset "tensors" begin
+                    arrays = [rand(1, 1, 2, 2), rand(1, 1, 2, 2), rand(1, 1, 2, 2)]
+                    ψ = MatrixProduct{Operator,Infinite}(arrays, order = (:l, :r, :i, :o))
+
+                    @test tensors(ψ, 1) isa Tensor
+                    @test length(ψ) == Inf
+                    @test tensors(ψ, 4) == tensors(ψ, 1)
+                    @test tensors(ψ, 0) == tensors(ψ, 3)
                 end
             end
         end

--- a/test/MatrixProductOperator_test.jl
+++ b/test/MatrixProductOperator_test.jl
@@ -76,6 +76,14 @@
                           only(select(ψ, last(ψ.interlayer)[3])).meta[:alias][:l]
                 end
             end
+
+            @testset "tensors" begin
+                arrays = [rand(1, 2, 2), rand(1, 1, 2, 2), rand(1, 2, 2)]
+                ψ = MatrixProduct{Operator,Open}(arrays, order = (:l, :r, :i, :o))
+
+                @test tensors(ψ, 1) isa Tensor
+                @test size(tensors(ψ)) |> first == length(ψ) == 3
+            end
         end
 
         @testset "`Periodic` boundary" begin
@@ -130,6 +138,14 @@
                           only(select(ψ, first(ψ.interlayer)[3])).meta[:alias][:l]
                     @test only(select(ψ, first(ψ.interlayer)[3])).meta[:alias][:r] ===
                           only(select(ψ, first(ψ.interlayer)[1])).meta[:alias][:l]
+                end
+
+                @testset "tensors" begin
+                    arrays = [rand(1, 1, 2, 2), rand(1, 1, 2, 2), rand(1, 1, 2, 2)]
+                    ψ = MatrixProduct{Operator,Periodic}(arrays, order = (:l, :r, :i, :o))
+
+                    @test tensors(ψ, 1) isa Tensor
+                    @test size(tensors(ψ)) |> first == length(ψ) == 3
                 end
             end
         end

--- a/test/MatrixProductState_test.jl
+++ b/test/MatrixProductState_test.jl
@@ -80,6 +80,14 @@
                     @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
                     @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
                 end
+
+                @testset "tensors" begin
+                    arrays = [rand(1, 2), rand(1, 1, 2), rand(1, 2)]
+                    ψ = MatrixProduct{State,Open}(arrays, order = (:l, :r, :o))
+
+                    @test tensors(ψ, 1) isa Tensor
+                    @test size(tensors(ψ)) |> first == length(ψ) == 3
+                end
             end
         end
 
@@ -127,6 +135,14 @@
                     @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
                     @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
                     @test tensors(ψ, 3).meta[:alias][:r] === tensors(ψ, 1).meta[:alias][:l]
+                end
+
+                @testset "tensors" begin
+                    arrays = [rand(1, 1, 2), rand(1, 1, 2), rand(1, 1, 2)]
+                    ψ = MatrixProduct{State,Periodic}(arrays, order = (:l, :r, :o))
+
+                    @test tensors(ψ, 1) isa Tensor
+                    @test size(tensors(ψ)) |> first == length(ψ) == 3
                 end
             end
         end

--- a/test/MatrixProductState_test.jl
+++ b/test/MatrixProductState_test.jl
@@ -80,14 +80,6 @@
                     @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
                     @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
                 end
-
-                @testset "tensors" begin
-                    arrays = [rand(1, 2), rand(1, 1, 2), rand(1, 2)]
-                    ψ = MatrixProduct{State,Open}(arrays, order = (:l, :r, :o))
-
-                    @test tensors(ψ, 1) isa Tensor
-                    @test size(tensors(ψ)) |> first == length(ψ) == 3
-                end
             end
         end
 
@@ -135,14 +127,6 @@
                     @test tensors(ψ, 1).meta[:alias][:r] === tensors(ψ, 2).meta[:alias][:l]
                     @test tensors(ψ, 2).meta[:alias][:r] === tensors(ψ, 3).meta[:alias][:l]
                     @test tensors(ψ, 3).meta[:alias][:r] === tensors(ψ, 1).meta[:alias][:l]
-                end
-
-                @testset "tensors" begin
-                    arrays = [rand(1, 1, 2), rand(1, 1, 2), rand(1, 1, 2)]
-                    ψ = MatrixProduct{State,Periodic}(arrays, order = (:l, :r, :o))
-
-                    @test tensors(ψ, 1) isa Tensor
-                    @test size(tensors(ψ)) |> first == length(ψ) == 3
                 end
             end
         end


### PR DESCRIPTION
### Summary

In this PR, we resolve #77 by extending our `MatrixProduct` and `ProjectedEntangledPair` types to include support for infinite boundary conditions, materialized in the infinite Matrix Product States (iMPS) and infinite Projected Entangled Pair States (iPEPS). This creates a structure where the tensors cycle periodically, emulating an infinite system by using a finite system unit cell that repeats itself. 

The `tensors`, `Base.show` and `Base.length` functions have been extended to support `TensorNetworks` with `Infinte` boundary conditions. Additional unit tests have been added to ensure the proper functioning of these new boundary conditions for both the `MPS` and `MPO` structures.

Nevertheless, the visualization of infinite boundary types is not yet supported and we should think about how to implement this.

### Example
Let's create a `MatrixProduct{State, Infinite}` which consists of a cell of three tensors that repeat indefinitely:
```julia
julia> _arrays = [rand(1, 1, 2), rand(1, 1, 2), rand(1, 1, 2)]
3-element Vector{Array{Float64, 3}}:
 [0.17136137178613753;;; 0.1659622523369414]
 [0.23387611601182623;;; 0.5187233455849274]
 [0.025368244393775274;;; 0.2701565528371912]

julia> ψ = MatrixProduct{State,Infinite}(_arrays, order = (:l, :r, :o))
TensorNetwork{MatrixProduct{State, Infinite}, NamedTuple{(:plug, :interlayer, :χ), Tuple{Type{<:Plug}, Vector{Bijection{Int64, Symbol}}, Union{Nothing, Int64}}}}(#tensors=∞, #labels=∞)

julia> tensors(ψ, 1) == tensors(ψ, 4) == tensors(ψ, -2)
true
```

