### PR TITLE
Enhance `Tranformations` docs

### DIFF
--- a/docs/src/transformations.md
+++ b/docs/src/transformations.md
@@ -14,11 +14,11 @@ transform!
 ```
 
 # Example
-Here we show how can we reduce the complexity of the tensor network by applying a tranformation to it:
+Here we show how can we reduce the complexity of the tensor network by applying a tranformation to it. We take as an example the Sycamore circuit from the [Google's quantum supremacy paper](https://www.nature.com/articles/s41586-019-1666-5)
+
 ```@setup plot
 using Makie
 Makie.inline!(true)
-set_theme!(resolution=(800,200))
 
 using CairoMakie
 using Tenet
@@ -50,9 +50,14 @@ function smooth_annotation!(f; color=Makie.RGBAf(110 // 256, 170 // 256, 250 // 
 
     poly!(ax, circle_points, color=color, closed=true)
 end
+
+bg_blue = Makie.RGBAf(110 // 256, 170 // 256, 250 // 256, 50 // 256) #hide
+orange = Makie.RGBf(240 // 256, 180 // 256, 100 // 256) #hide
+red = Makie.RGBf(240 // 256, 90 // 256, 70 // 256) #hide
 ```
 ```@example plot
 using QuacIO
+set_theme!(resolution=(800,400)) # hide
 
 sites = [5, 6, 14, 15, 16, 17, 24, 25, 26, 27, 28, 32, 33, 34, 35, 36, 37, 38, 39, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 61, 62, 63, 64, 65, 66, 67, 72, 73, 74, 75, 76, 83, 84, 85, 94]
 circuit = QuacIO.parse(joinpath(@__DIR__, "sycamore_53_10_0.qasm"), format=QuacIO.Qflex(), sites=sites)
@@ -60,19 +65,26 @@ tn = TensorNetwork(circuit)
 transformed_tn = transform(tn, Tenet.RankSimplification)
 
 fig = Figure() # hide
-ax1 = Axis(fig[1, 1]; title="Original TensorNetwork") # hide
-p1 = plot!(ax1, tn; node_size=5.) # hide
-ax2 = Axis(fig[1, 2], title="Transformed TensorNetwork") # hide
-p2 = plot!(ax2, transformed_tn; node_size=5.) # hide
-ax1.titlesize=20 # hide
-ax2.titlesize=20 # hide
+ax1 = Axis(fig[1, 1]) # hide
+p1 = plot!(ax1, tn; edge_width=0.75, node_size=8., node_attr=(strokecolor=:black, strokewidth=0.5)) # hide
+ax2 = Axis(fig[1, 2]) # hide
+p2 = plot!(ax2, transformed_tn; edge_width=0.75, node_size=8., node_attr=(strokecolor=:black, strokewidth=0.5)) # hide
+ax1.titlesize, ax2.titlesize = 20, 20 # hide
+hidedecorations!(ax1) # hide
+hidespines!(ax1) # hide
+hidedecorations!(ax2) # hide
+hidespines!(ax2) # hide
+
+Label(fig[1, 1, Bottom()], "Original Tensor Network") # hide
+Label(fig[1, 2, Bottom()], "Transformed Tensor Network") # hide
+
 fig # hide
 ```
 
 # Transformations
 
-## Rank simplification
-!!! warn ""
+## Hyperindex converter
+!!! warn "Note"
     This transformation is always used by default when visualizing a `TensorNetwork` with `plot`.
 ```@docs
 Tenet.HyperindConverter
@@ -80,122 +92,222 @@ Tenet.HyperindConverter
 
 ## Diagonal reduction
 ```@example plot
-    fig = Figure() #hide
+set_theme!(resolution=(800,200)) # hide
+fig = Figure() #hide
 
-    data = zeros(Float64, 2, 2, 2, 2) #hide
-    for i in 1:2 #hide
-        for j in 1:2 #hide
-            for k in 1:2 #hide
-                data[i, i, j, k] = k #hide
-            end #hide
+data = zeros(Float64, 2, 2, 2, 2) #hide
+for i in 1:2 #hide
+    for j in 1:2 #hide
+        for k in 1:2 #hide
+            data[i, i, j, k] = k #hide
         end #hide
     end #hide
+end #hide
 
-    A = Tensor(data, (:i, :j, :k, :l)) #hide
-    B = Tensor(rand(2, 2), (:i, :m)) #hide
-    C = Tensor(rand(2, 2), (:j, :n)) #hide
+A = Tensor(data, (:i, :j, :k, :l)) #hide
+B = Tensor(rand(2, 2), (:i, :m)) #hide
+C = Tensor(rand(2, 2), (:j, :n)) #hide
 
-    bg_blue = Makie.RGBAf(110 // 256, 170 // 256, 250 // 256, 50 // 256) #hide
-    orange = Makie.RGBf(240 // 256, 180 // 256, 100 // 256) #hide
-    red = Makie.RGBf(240 // 256, 90 // 256, 70 // 256) #hide
+tn = TensorNetwork([A, B, C]) #hide
+reduced = transform(tn, Tenet.DiagonalReduction) #hide
 
-    tn = TensorNetwork([A, B, C]) #hide
-    reduced = transform(tn, Tenet.DiagonalReduction) #hide
+smooth_annotation!( #hide
+    fig[1, 1]; #hide
+    color = bg_blue, #hide
+    xlims = [-2, 2], #hide
+    ylims = [-2, 2], #hide
+    offset_x = -0.21, #hide
+    offset_y = -0.42, #hide
+    radius_x = 0.38, #hide
+    radius_y = 0.8, #hide
+    num_waves = 6, #hide
+    fluctuation_amplitude = 0.02, #hide
+    phase_shift = 0.0) #hide
+plot!(fig[1, 1], tn, layout=Spring(iterations=1000, C=0.5, seed=100); node_color=[red, orange, orange, :black, :black,:black, :black]) #hide
 
-    smooth_annotation!( #hide
-        fig[1, 1]; #hide
-        color = bg_blue, #hide
-        xlims = [-2, 2], #hide
-        ylims = [-2, 2], #hide
-        offset_x = -0.21, #hide
-        offset_y = -0.42, #hide
-        radius_x = 0.38, #hide
-        radius_y = 0.8, #hide
-        num_waves = 6, #hide
-        fluctuation_amplitude = 0.02, #hide
-        phase_shift = 0.0) #hide
-    plot!(fig[1, 1], tn, layout=Spring(iterations=1000, C=0.5, seed=100); node_color=[red, orange, orange, :black, :black,:black, :black]) #hide
+smooth_annotation!( #hide
+    fig[1, 2]; #hide
+    color = bg_blue, #hide
+    xlims = [-2, 2], #hide
+    ylims = [-2, 2], #hide
+    offset_x = 0.1, #hide
+    offset_y = -0.35, #hide
+    radius_x = 0.38, #hide
+    radius_y = 1.1, #hide
+    num_waves = 5, #hide
+    fluctuation_amplitude = 0.02, #hide
+    phase_shift = 1.9) #hide
+plot!(fig[1, 2], reduced, layout=Spring(iterations=1000, C=0.5, seed=100),  node_color=[orange, orange, red, :black, :black, :black, :black, :black]) #hide
 
-    smooth_annotation!( #hide
-        fig[1, 2]; #hide
-        color = bg_blue, #hide
-        xlims = [-2, 2], #hide
-        ylims = [-2, 2], #hide
-        offset_x = 0.1, #hide
-        offset_y = -0.35, #hide
-        radius_x = 0.38, #hide
-        radius_y = 1.1, #hide
-        num_waves = 5, #hide
-        fluctuation_amplitude = 0.02, #hide
-        phase_shift = 1.9) #hide
-    plot!(fig[1, 2], reduced, layout=Spring(iterations=1000, C=0.5, seed=100),  node_color=[orange, orange, red, :black, :black, :black, :black, :black]) #hide
+Label(fig[1, 1, Bottom()], "Original Tensor Network") #hide
+Label(fig[1, 2, Bottom()], "Transformed Tensor Network") #hide
 
-    Label(fig[1, 1, Bottom()], "Original Tensor Network") #hide
-    Label(fig[1, 2, Bottom()], "Transformed Tensor Network") #hide
-
-    fig #hide
+fig #hide
 ```
 
 ```@docs
 Tenet.DiagonalReduction
 ```
 
-## Rank reduction
+## Anti-diagonal reduction
 ```@docs
-Tenet.RankReduction
+Tenet.AntiDiagonalGauging
+```
+
+## Rank simplification
+```@docs
+Tenet.RankSimplification
 ```
 
 ```@example plot
-    fig = Figure() #hide
+set_theme!(resolution=(800,200)) # hide
+fig = Figure() #hide
 
-    A = Tensor(rand(2, 2, 2, 2), (:i, :j, :k, :l)) #hide
-    B = Tensor(rand(2, 2), (:i, :m)) #hide
-    C = Tensor(rand(2, 2, 2), (:m, :n, :o)) #hide
-    E = Tensor(rand(2, 2, 2, 2), (:o, :p, :q, :j)) #hide
+A = Tensor(rand(2, 2, 2, 2), (:i, :j, :k, :l)) #hide
+B = Tensor(rand(2, 2), (:i, :m)) #hide
+C = Tensor(rand(2, 2, 2), (:m, :n, :o)) #hide
+E = Tensor(rand(2, 2, 2, 2), (:o, :p, :q, :j)) #hide
 
-    bg_blue = Makie.RGBAf(110 // 256, 170 // 256, 250 // 256, 50 // 256) #hide
-    orange = Makie.RGBf(240 // 256, 180 // 256, 100 // 256) #hide
-    red = Makie.RGBf(240 // 256, 90 // 256, 70 // 256) #hide
+tn = TensorNetwork([A, B, C, E]) #hide
+reduced = transform(tn, Tenet.RankSimplification) #hide
 
-    tn = TensorNetwork([A, B, C, E]) #hide
-    reduced = transform(tn, Tenet.RankSimplification) #hide
+smooth_annotation!( #hide
+    fig[1, 1]; #hide
+    color = bg_blue, #hide
+    xlims = [-2, 2], #hide
+    ylims = [-2, 2], #hide
+    offset_x = -0.32, #hide
+    offset_y = -0.5, #hide
+    radius_x = 0.25, #hide
+    radius_y = 0.94, #hide
+    num_waves = 6, #hide
+    fluctuation_amplitude = 0.01, #hide
+    phase_shift = 0.0) #hide
+plot!(fig[1, 1], tn, layout=Spring(iterations=1000, C=0.5, seed=20); node_color=[orange, red, orange, orange, :black, :black, :black, :black, :black]) #hide
 
-    smooth_annotation!( #hide
-        fig[1, 1]; #hide
-        color = bg_blue, #hide
-        xlims = [-2, 2], #hide
-        ylims = [-2, 2], #hide
-        offset_x = -0.32, #hide
-        offset_y = -0.5, #hide
-        radius_x = 0.25, #hide
-        radius_y = 0.94, #hide
-        num_waves = 6, #hide
-        fluctuation_amplitude = 0.01, #hide
-        phase_shift = 0.0) #hide
-    plot!(fig[1, 1], tn, layout=Spring(iterations=1000, C=0.5, seed=20); node_color=[orange, red, orange, orange, :black, :black, :black, :black, :black]) #hide
+smooth_annotation!( #hide
+    fig[1, 2]; #hide
+    color = bg_blue, #hide
+    xlims = [-2, 2], #hide
+    ylims = [-2, 2], #hide
+    offset_x = 0.12, #hide
+    offset_y = -0.62, #hide
+    radius_x = 0.18, #hide
+    radius_y = 0.46, #hide
+    num_waves = 5, #hide
+    fluctuation_amplitude = 0.01, #hide
+    phase_shift = 0) #hide
+plot!(fig[1, 2], reduced, layout=Spring(iterations=1000, C=0.5, seed=1); node_color=[red, orange, orange, :black, :black, :black, :black, :black]) #hide
 
-    smooth_annotation!( #hide
-        fig[1, 2]; #hide
-        color = bg_blue, #hide
-        xlims = [-2, 2], #hide
-        ylims = [-2, 2], #hide
-        offset_x = 0.12, #hide
-        offset_y = -0.62, #hide
-        radius_x = 0.18, #hide
-        radius_y = 0.46, #hide
-        num_waves = 5, #hide
-        fluctuation_amplitude = 0.01, #hide
-        phase_shift = 0) #hide
-    plot!(fig[1, 2], reduced, layout=Spring(iterations=1000, C=0.5, seed=1); node_color=[red, orange, orange, :black, :black, :black, :black, :black]) #hide
+Label(fig[1, 1, Bottom()], "Original Tensor Network") #hide
+Label(fig[1, 2, Bottom()], "Transformed Tensor Network") #hide
 
-    Label(fig[1, 1, Bottom()], "Original Tensor Network") #hide
-    Label(fig[1, 2, Bottom()], "Transformed Tensor Network") #hide
-
-    fig #hide
+fig #hide
 ```
 
+## Column reduction
+
 ```@docs
-Tenet.AntiDiagonalGauging
 Tenet.ColumnReduction
+```
+
+```@example plot
+set_theme!(resolution=(800,200)) # hide
+fig = Figure() #hide
+
+data = rand(3, 3, 3) #hide
+data[:, 1:2, :] .= 0 #hide
+
+A = Tensor(data, (:i, :j, :k)) #hide
+B = Tensor(rand(3, 3), (:j, :l)) #hide
+C = Tensor(rand(3, 3), (:l, :m)) #hide
+
+tn = TensorNetwork([A, B, C]) #hide
+reduced = transform(tn, Tenet.ColumnReduction) #hide
+
+smooth_annotation!( #hide
+    fig[1, 1]; #hide
+    color = bg_blue, #hide
+    xlims = [-2, 2], #hide
+    ylims = [-2, 2], #hide
+    offset_x = -1.12, #hide
+    offset_y = -0.22, #hide
+    radius_x = 0.35, #hide
+    radius_y = 0.84, #hide
+    num_waves = 4, #hide
+    fluctuation_amplitude = 0.02, #hide
+    phase_shift = 0.0) #hide
+plot!(fig[1, 1], tn, layout=Spring(iterations=1000, C=0.5, seed=6); node_color=[red, orange, orange, :black, :black, :black]) #hide
+
+smooth_annotation!( #hide
+    fig[1, 2]; #hide
+    color = bg_blue, #hide
+    xlims = [-2, 2], #hide
+    ylims = [-2, 2], #hide
+    offset_x = -0.64, #hide
+    offset_y = 1.2, #hide
+    radius_x = 0.32, #hide
+    radius_y = 0.78, #hide
+    num_waves = 5, #hide
+    fluctuation_amplitude = 0.02, #hide
+    phase_shift = 0) #hide
+
+Label(fig[1, 1, Bottom()], "Original Tensor Network") #hide
+Label(fig[1, 2, Bottom()], "Transformed Tensor Network") #hide
+plot!(fig[1, 2], reduced, layout=Spring(iterations=2000, C=40, seed=8); node_color=[red, orange, orange, :black, :black, :black]) #hide
+
+fig #hide
+```
+
+## Split simplification
+```@docs
 Tenet.SplitSimplification
+```
+
+```@example plot
+set_theme!(resolution=(800,200)) # hide
+fig = Figure() #hide
+
+v1 = Tensor([1, 2, 3], (:i,)) #hide
+v2 = Tensor([4, 5, 6], (:j,)) #hide
+m1 = Tensor(rand(3, 3), (:k, :l)) #hide
+
+t1 = contract(v1, v2) #hide
+tensor = contract(t1, m1)  #hide
+
+tn = TensorNetwork([tensor, Tensor(rand(3, 3, 3), (:k, :m, :n)), Tensor(rand(3, 3, 3), (:l, :n, :o))]) #hide
+reduced = transform(tn, Tenet.SplitSimplification) #hide
+
+smooth_annotation!( #hide
+    fig[1, 1]; #hide
+    color = bg_blue, #hide
+    xlims = [-2, 2], #hide
+    ylims = [-2, 2], #hide
+    offset_x = 0.24, #hide
+    offset_y = 0.6, #hide
+    radius_x = 0.32, #hide
+    radius_y = 0.78, #hide
+    num_waves = 5, #hide
+    fluctuation_amplitude = 0.015, #hide
+    phase_shift = 0.0) #hide
+plot!(fig[1, 1], tn, layout=Spring(iterations=10000, C=0.5, seed=12); node_color=[red, orange,  orange, :black, :black, :black, :black]) #hide
+
+smooth_annotation!( #hide
+    fig[1, 2]; #hide
+    color = bg_blue, #hide
+    xlims = [-2, 2], #hide
+    ylims = [-2, 2], #hide
+    offset_x = -0.2, #hide
+    offset_y = -0.4, #hide
+    radius_x = 1.1, #hide
+    radius_y = 0.75, #hide
+    num_waves = 3, #hide
+    fluctuation_amplitude = 0.18, #hide
+    phase_shift = 0.8) #hide
+
+Label(fig[1, 1, Bottom()], "Original Tensor Network") #hide
+Label(fig[1, 2, Bottom()], "Transformed Tensor Network") #hide
+plot!(fig[1, 2], reduced, layout=Spring(iterations=10000, C=13, seed=151); node_color=[orange, orange, red, red, red, :black, :black, :black, :black]) #hide
+
+fig #hide
 ```

--- a/docs/src/transformations.md
+++ b/docs/src/transformations.md
@@ -77,8 +77,8 @@ hidespines!(ax1) # hide
 hidedecorations!(ax2) # hide
 hidespines!(ax2) # hide
 
-Label(fig[1, 1, Bottom()], "Original Tensor Network") # hide
-Label(fig[1, 2, Bottom()], "Transformed Tensor Network") # hide
+Label(fig[1, 1, Bottom()], "Original") # hide
+Label(fig[1, 2, Bottom()], "Transformed") # hide
 
 fig # hide
 ```
@@ -139,8 +139,8 @@ smooth_annotation!( #hide
     phase_shift = 1.9) #hide
 plot!(fig[1, 2], reduced, layout=Spring(iterations=1000, C=0.5, seed=100),  node_color=[orange, orange, red, :black, :black, :black, :black, :black]) #hide
 
-Label(fig[1, 1, Bottom()], "Original Tensor Network") #hide
-Label(fig[1, 2, Bottom()], "Transformed Tensor Network") #hide
+Label(fig[1, 1, Bottom()], "Original") #hide
+Label(fig[1, 2, Bottom()], "Transformed") #hide
 
 fig #hide
 ```
@@ -199,8 +199,8 @@ smooth_annotation!( #hide
     phase_shift = 0) #hide
 plot!(fig[1, 2], reduced, layout=Spring(iterations=1000, C=0.5, seed=1); node_color=[red, orange, orange, :black, :black, :black, :black, :black]) #hide
 
-Label(fig[1, 1, Bottom()], "Original Tensor Network") #hide
-Label(fig[1, 2, Bottom()], "Transformed Tensor Network") #hide
+Label(fig[1, 1, Bottom()], "Original") #hide
+Label(fig[1, 2, Bottom()], "Transformed") #hide
 
 fig #hide
 ```
@@ -252,8 +252,8 @@ smooth_annotation!( #hide
     fluctuation_amplitude = 0.02, #hide
     phase_shift = 0) #hide
 
-Label(fig[1, 1, Bottom()], "Original Tensor Network") #hide
-Label(fig[1, 2, Bottom()], "Transformed Tensor Network") #hide
+Label(fig[1, 1, Bottom()], "Original") #hide
+Label(fig[1, 2, Bottom()], "Transformed") #hide
 plot!(fig[1, 2], reduced, layout=Spring(iterations=2000, C=40, seed=8); node_color=[red, orange, orange, :black, :black, :black]) #hide
 
 fig #hide
@@ -305,8 +305,8 @@ smooth_annotation!( #hide
     fluctuation_amplitude = 0.18, #hide
     phase_shift = 0.8) #hide
 
-Label(fig[1, 1, Bottom()], "Original Tensor Network") #hide
-Label(fig[1, 2, Bottom()], "Transformed Tensor Network") #hide
+Label(fig[1, 1, Bottom()], "Original") #hide
+Label(fig[1, 2, Bottom()], "Transformed") #hide
 plot!(fig[1, 2], reduced, layout=Spring(iterations=10000, C=13, seed=151); node_color=[orange, orange, red, red, red, :black, :black, :black, :black]) #hide
 
 fig #hide

--- a/docs/src/transformations.md
+++ b/docs/src/transformations.md
@@ -62,7 +62,9 @@ set_theme!(resolution=(800,400)) # hide
 sites = [5, 6, 14, 15, 16, 17, 24, 25, 26, 27, 28, 32, 33, 34, 35, 36, 37, 38, 39, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 61, 62, 63, 64, 65, 66, 67, 72, 73, 74, 75, 76, 83, 84, 85, 94]
 circuit = QuacIO.parse(joinpath(@__DIR__, "sycamore_53_10_0.qasm"), format=QuacIO.Qflex(), sites=sites)
 tn = TensorNetwork(circuit)
-transformed_tn = transform(tn, Tenet.RankSimplification)
+
+# Apply transformations to the tensor network
+transformed_tn = transform(tn, [Tenet.AntiDiagonalGauging, Tenet.DiagonalReduction, Tenet.ColumnReduction, Tenet.RankSimplification])
 
 fig = Figure() # hide
 ax1 = Axis(fig[1, 1]) # hide

--- a/docs/src/transformations.md
+++ b/docs/src/transformations.md
@@ -84,8 +84,6 @@ fig # hide
 # Transformations
 
 ## Hyperindex converter
-!!! warn "Note"
-    This transformation is always used by default when visualizing a `TensorNetwork` with `plot`.
 ```@docs
 Tenet.HyperindConverter
 ```

--- a/docs/src/transformations.md
+++ b/docs/src/transformations.md
@@ -13,7 +13,7 @@ transform
 transform!
 ```
 
-# Example
+# Example: RQC simplification
 Here we show how can we reduce the complexity of the tensor network by applying a tranformation to it. We take as an example the Sycamore circuit from the [Google's quantum supremacy paper](https://www.nature.com/articles/s41586-019-1666-5)
 
 ```@setup plot

--- a/docs/src/transformations.md
+++ b/docs/src/transformations.md
@@ -91,6 +91,10 @@ Tenet.HyperindConverter
 ```
 
 ## Diagonal reduction
+```@docs
+Tenet.DiagonalReduction
+```
+
 ```@example plot
 set_theme!(resolution=(800,200)) # hide
 fig = Figure() #hide
@@ -143,10 +147,6 @@ Label(fig[1, 1, Bottom()], "Original") #hide
 Label(fig[1, 2, Bottom()], "Transformed") #hide
 
 fig #hide
-```
-
-```@docs
-Tenet.DiagonalReduction
 ```
 
 ## Anti-diagonal reduction

--- a/docs/src/transformations.md
+++ b/docs/src/transformations.md
@@ -16,16 +16,43 @@ transform!
 # Example
 Here we show how can we reduce the complexity of the tensor network by applying a tranformation to it:
 ```@setup plot
+using Makie
+Makie.inline!(true)
+set_theme!(resolution=(800,200))
+
 using CairoMakie
-CairoMakie.activate!(type = "svg")
+using Tenet
+using NetworkLayout
 
 using Pkg
 Pkg.add("QuacIO")
+
+function smooth_annotation!(f; color=Makie.RGBAf(110 // 256, 170 // 256, 250 // 256, 60 // 256), xlims=[-2, 2], ylims=[-2, 2], offset_x=0.0, offset_y=0.0, radius_x=1.0, radius_y=1.0, num_waves=5, fluctuation_amplitude=0.1, phase_shift=0.0)
+    ax = Axis(f)
+    hidedecorations!(ax)
+    hidespines!(ax)
+
+    # Define limits of the plot
+    xlims!(ax, xlims...)
+    ylims!(ax, ylims...)
+
+    # Create a perturbed filled shape
+    theta = LinRange(0, 2π, 100)
+
+    fluctuations = fluctuation_amplitude .* sin.(num_waves .* theta .+ phase_shift)
+
+    # Apply the fluctuations and radius scaling
+    perturbed_radius_x = radius_x .+ fluctuations
+    perturbed_radius_y = radius_y .+ fluctuations
+
+    circle_points = [Point2f((perturbed_radius_x[i]) * cos(theta[i]) + offset_x,
+                              (perturbed_radius_y[i]) * sin(theta[i]) + offset_y) for i in 1:length(theta)]
+
+    poly!(ax, circle_points, color=color, closed=true)
+end
 ```
-```@example transformation
+```@example plot
 using QuacIO
-using CairoMakie
-using Tenet
 
 sites = [5, 6, 14, 15, 16, 17, 24, 25, 26, 27, 28, 32, 33, 34, 35, 36, 37, 38, 39, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 61, 62, 63, 64, 65, 66, 67, 72, 73, 74, 75, 76, 83, 84, 85, 94]
 circuit = QuacIO.parse(joinpath(@__DIR__, "sycamore_53_10_0.qasm"), format=QuacIO.Qflex(), sites=sites)
@@ -44,10 +71,130 @@ fig # hide
 
 # Transformations
 
+## Rank simplification
+!!! warn ""
+    This transformation is always used by default when visualizing a `TensorNetwork` with `plot`.
 ```@docs
 Tenet.HyperindConverter
+```
+
+## Diagonal reduction
+```@example plot
+    fig = Figure() #hide
+
+    data = zeros(Float64, 2, 2, 2, 2) #hide
+    for i in 1:2 #hide
+        for j in 1:2 #hide
+            for k in 1:2 #hide
+                data[i, i, j, k] = k #hide
+            end #hide
+        end #hide
+    end #hide
+
+    A = Tensor(data, (:i, :j, :k, :l)) #hide
+    B = Tensor(rand(2, 2), (:i, :m)) #hide
+    C = Tensor(rand(2, 2), (:j, :n)) #hide
+
+    bg_blue = Makie.RGBAf(110 // 256, 170 // 256, 250 // 256, 50 // 256) #hide
+    orange = Makie.RGBf(240 // 256, 180 // 256, 100 // 256) #hide
+    red = Makie.RGBf(240 // 256, 90 // 256, 70 // 256) #hide
+
+    tn = TensorNetwork([A, B, C]) #hide
+    reduced = transform(tn, Tenet.DiagonalReduction) #hide
+
+    smooth_annotation!( #hide
+        fig[1, 1]; #hide
+        color = bg_blue, #hide
+        xlims = [-2, 2], #hide
+        ylims = [-2, 2], #hide
+        offset_x = -0.21, #hide
+        offset_y = -0.42, #hide
+        radius_x = 0.38, #hide
+        radius_y = 0.8, #hide
+        num_waves = 6, #hide
+        fluctuation_amplitude = 0.02, #hide
+        phase_shift = 0.0) #hide
+    plot!(fig[1, 1], tn, layout=Spring(iterations=1000, C=0.5, seed=100); node_color=[red, orange, orange, :black, :black,:black, :black]) #hide
+
+    smooth_annotation!( #hide
+        fig[1, 2]; #hide
+        color = bg_blue, #hide
+        xlims = [-2, 2], #hide
+        ylims = [-2, 2], #hide
+        offset_x = 0.1, #hide
+        offset_y = -0.35, #hide
+        radius_x = 0.38, #hide
+        radius_y = 1.1, #hide
+        num_waves = 5, #hide
+        fluctuation_amplitude = 0.02, #hide
+        phase_shift = 1.9) #hide
+    plot!(fig[1, 2], reduced, layout=Spring(iterations=1000, C=0.5, seed=100),  node_color=[orange, orange, red, :black, :black, :black, :black, :black]) #hide
+
+    Label(fig[1, 1, Bottom()], "Original Tensor Network") #hide
+    Label(fig[1, 2, Bottom()], "Transformed Tensor Network") #hide
+
+    fig #hide
+```
+
+```@docs
 Tenet.DiagonalReduction
-Tenet.RankSimplification
+```
+
+## Rank reduction
+```@docs
+Tenet.RankReduction
+```
+
+```@example plot
+    fig = Figure() #hide
+
+    A = Tensor(rand(2, 2, 2, 2), (:i, :j, :k, :l)) #hide
+    B = Tensor(rand(2, 2), (:i, :m)) #hide
+    C = Tensor(rand(2, 2, 2), (:m, :n, :o)) #hide
+    E = Tensor(rand(2, 2, 2, 2), (:o, :p, :q, :j)) #hide
+
+    bg_blue = Makie.RGBAf(110 // 256, 170 // 256, 250 // 256, 50 // 256) #hide
+    orange = Makie.RGBf(240 // 256, 180 // 256, 100 // 256) #hide
+    red = Makie.RGBf(240 // 256, 90 // 256, 70 // 256) #hide
+
+    tn = TensorNetwork([A, B, C, E]) #hide
+    reduced = transform(tn, Tenet.RankSimplification) #hide
+
+    smooth_annotation!( #hide
+        fig[1, 1]; #hide
+        color = bg_blue, #hide
+        xlims = [-2, 2], #hide
+        ylims = [-2, 2], #hide
+        offset_x = -0.32, #hide
+        offset_y = -0.5, #hide
+        radius_x = 0.25, #hide
+        radius_y = 0.94, #hide
+        num_waves = 6, #hide
+        fluctuation_amplitude = 0.01, #hide
+        phase_shift = 0.0) #hide
+    plot!(fig[1, 1], tn, layout=Spring(iterations=1000, C=0.5, seed=20); node_color=[orange, red, orange, orange, :black, :black, :black, :black, :black]) #hide
+
+    smooth_annotation!( #hide
+        fig[1, 2]; #hide
+        color = bg_blue, #hide
+        xlims = [-2, 2], #hide
+        ylims = [-2, 2], #hide
+        offset_x = 0.12, #hide
+        offset_y = -0.62, #hide
+        radius_x = 0.18, #hide
+        radius_y = 0.46, #hide
+        num_waves = 5, #hide
+        fluctuation_amplitude = 0.01, #hide
+        phase_shift = 0) #hide
+    plot!(fig[1, 2], reduced, layout=Spring(iterations=1000, C=0.5, seed=1); node_color=[red, orange, orange, :black, :black, :black, :black, :black]) #hide
+
+    Label(fig[1, 1, Bottom()], "Original Tensor Network") #hide
+    Label(fig[1, 2, Bottom()], "Transformed Tensor Network") #hide
+
+    fig #hide
+```
+
+```@docs
 Tenet.AntiDiagonalGauging
 Tenet.ColumnReduction
 Tenet.SplitSimplification

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -345,6 +345,10 @@ function find_zero_columns(x; atol = 1e-12)
 end
 
 function find_diag_axes(x; atol = 1e-12)
+    if ndims(parent(x)) == 1 # Skip 1D tensors
+        return []
+    end
+
     # find all the potential diagonals
     potential_diag_axes = [(i, j) for i in 1:ndims(x) for j in i+1:ndims(x) if size(x, i) == size(x, j)]
 
@@ -367,6 +371,10 @@ function find_diag_axes(x; atol = 1e-12)
 end
 
 function find_anti_diag_axes(x; atol = 1e-12)
+    if ndims(parent(x)) == 1 # Skip 1D tensors
+        return []
+    end
+
     # Find all the potential anti-diagonals
     potential_anti_diag_axes = [(i, j) for i in 1:ndims(x) for j in i+1:ndims(x) if size(x, i) == size(x, j)]
 

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -39,6 +39,7 @@ end
     HyperindConverter <: Transformation
 
 Convert hyperindices to COPY-tensors, represented by `DeltaArray`s.
+This transformation is always used by default when visualizing a `TensorNetwork` with `plot`.
 """
 struct HyperindConverter <: Transformation end
 

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -92,7 +92,7 @@ function transform!(tn::TensorNetwork, config::DiagonalReduction)
             # insert COPY tensor
             new_index = Symbol(uuid4())
             data = DeltaArray{N + 1}(ones(size(target, first(inds))))
-            push!(copies, Tensor(data, (new_index, inds...)))
+            push!(copies, Tensor(data, (new_index, inds...), dual = new_index))
 
             # extract diagonal of target tensor
             # TODO rewrite using `einsum!` when implemented in Tensors

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -346,9 +346,8 @@ function find_zero_columns(x; atol = 1e-12)
 end
 
 function find_diag_axes(x; atol = 1e-12)
-    if ndims(parent(x)) == 1 # Skip 1D tensors
-        return []
-    end
+    # skip 1D tensors
+    ndims(parent(x)) == 1 && return []
 
     # find all the potential diagonals
     potential_diag_axes = [(i, j) for i in 1:ndims(x) for j in i+1:ndims(x) if size(x, i) == size(x, j)]
@@ -372,9 +371,8 @@ function find_diag_axes(x; atol = 1e-12)
 end
 
 function find_anti_diag_axes(x; atol = 1e-12)
-    if ndims(parent(x)) == 1 # Skip 1D tensors
-        return []
-    end
+    # skip 1D tensors
+    ndims(parent(x)) == 1 && return []
 
     # Find all the potential anti-diagonals
     potential_anti_diag_axes = [(i, j) for i in 1:ndims(x) for j in i+1:ndims(x) if size(x, i) == size(x, j)]


### PR DESCRIPTION
### Summary
This PR enhances the documentation of the `transform` functions. We fixed the previous text and, for the transformations that enabled it, we added a small visual example showing how that particular transformation work.

Moreover, we fixed a minor problem in the `DiagonalReduction` transformation, where the COPY tensor created did not have the `dual` metadata, which is necessary to display the transformed tensor network correctly.