### PR TITLE
Add `lu` decomposition for `Tensor`s

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Muscle = "21fe5c4b-a943-414d-bf3e-516f24900631"
 OMEinsum = "ebe7aa44-baf0-506c-a96f-8464559b3922"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 ValSplit = "0625e100-946b-11ec-09cd-6328dd093154"
 

--- a/docs/src/tensors.md
+++ b/docs/src/tensors.md
@@ -63,3 +63,11 @@ length(Tᵢⱼₖ)
 ```@docs
 Tenet.contract(::Tensor, ::Tensor)
 ```
+
+### Factorizations
+
+```@docs
+LinearAlgebra.svd(::Tensor)
+LinearAlgebra.qr(::Tensor)
+LinearAlgebra.lu(::Tensor)
+```

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -136,15 +136,15 @@ end
 LinearAlgebra.qr(t::Tensor{<:Any,2}; kwargs...) = Base.@invoke qr(t::Tensor; left_inds = (first(inds(t)),), kwargs...)
 
 """
-    LinearAlgebra.qr(t::Tensor, mode::Symbol = :reduced; left_inds = (), right_inds = (), virtualind::Symbol = Symbol(uuid4()), kwargs...
+    LinearAlgebra.qr(tensor::Tensor; left_inds, right_inds, virtualind, kwargs...)
 
 Perform QR factorization on a tensor.
 
-# Keyword Arguments
+# Keyword arguments
 
-    - `left_inds`: left indices to be used in the QR factorization. Defaults to all indices of `t` except `right_inds`.
-    - `right_inds`: right indices to be used in the QR factorization. Defaults to all indices of `t` except `left_inds`.
-    - `virtualind`: name of the virtual bond. Defaults to a random `Symbol`.
+  - `left_inds`: left indices to be used in the QR factorization. Defaults to all indices of `t` except `right_inds`.
+  - `right_inds`: right indices to be used in the QR factorization. Defaults to all indices of `t` except `left_inds`.
+  - `virtualind`: name of the virtual bond. Defaults to a random `Symbol`.
 """
 function LinearAlgebra.qr(
     tensor::Tensor;
@@ -178,15 +178,15 @@ end
 LinearAlgebra.lu(t::Tensor{<:Any,2}; kwargs...) = Base.@invoke lu(t::Tensor; left_inds = (first(inds(t)),), kwargs...)
 
 """
-    LinearAlgebra.lu(t::Tensor, ...)
+    LinearAlgebra.lu(tensor::Tensor; left_inds, right_inds, virtualind, kwargs...)
 
 Perform LU factorization on a tensor.
 
-# Keyword Arguments
+# Keyword arguments
 
-    - `left_inds`: left indices to be used in the QR factorization. Defaults to all indices of `t` except `right_inds`.
-    - `right_inds`: right indices to be used in the QR factorization. Defaults to all indices of `t` except `left_inds`.
-    - `virtualind`: name of the virtual bond. Defaults to a random `Symbol`.
+  - `left_inds`: left indices to be used in the LU factorization. Defaults to all indices of `t` except `right_inds`.
+  - `right_inds`: right indices to be used in the LU factorization. Defaults to all indices of `t` except `left_inds`.
+  - `virtualind`: name of the virtual bond. Defaults to a random `Symbol`.
 """
 function LinearAlgebra.lu(
     tensor::Tensor;

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -85,7 +85,7 @@ function factorinds(tensor, left_inds, right_inds)
         throw(ArgumentError("left ($left_inds) and right $(right_inds) indices must be disjoint"))
 
     left_inds, right_inds =
-        isempty(left_inds) ? (setdiff(inds(t), right_inds), right_inds) :
+        isempty(left_inds) ? (setdiff(inds(tensor), right_inds), right_inds) :
         isempty(right_inds) ? (left_inds, setdiff(inds(tensor), left_inds)) :
         throw(ArgumentError("cannot set both left and right indices"))
 

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -171,9 +171,9 @@ LinearAlgebra.lu(t::Tensor; left_inds=(), kwargs...) = lu(t, left_inds; kwargs..
 function LinearAlgebra.lu(t::Tensor, left_inds; kwargs...)
    # TODO better error exception and checks
    isempty(left_inds) && throw(ErrorException("no left-indices in LU factorization"))
-   left_inds ⊆ labels(t) || throw(ErrorException("all left-indices must be in $(labels(t))"))
+   left_inds ⊆ inds(t) || throw(ErrorException("all left-indices must be in $(inds(t))"))
 
-   right_inds = setdiff(labels(t), left_inds)
+   right_inds = setdiff(inds(t), left_inds)
    isempty(right_inds) && throw(ErrorException("no right-indices in LU factorization"))
 
    # permute array

--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -157,7 +157,7 @@ Base.selectdim(t::Tensor, d::Symbol, i) = selectdim(t, dim(t, d), i)
 Base.permutedims(t::Tensor, perm) = Tensor(permutedims(parent(t), perm), getindex.((inds(t),), perm))
 Base.permutedims!(dest::Tensor, src::Tensor, perm) = permutedims!(parent(dest), parent(src), perm)
 
-function Base.permutedims(t::Tensor{T,N}, perm::NTuple{N,Symbol}) where {T,N}
+function Base.permutedims(t::Tensor{T}, perm::Base.AbstractVecOrTuple{Symbol}) where {T}
     perm = map(i -> findfirst(==(i), inds(t)), perm)
     permutedims(t, perm)
 end

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -255,7 +255,7 @@ function transform!(tn::AbstractTensorNetwork, config::SplitSimplification)
             rank_s = sum(s .> config.atol)
 
             if rank_s < length(s)
-                hyperindex = only(inds(s))
+                hyperindex = only(Tenet.inds(s))
 
                 # truncate data
                 u = view(u, hyperindex => 1:rank_s)

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -249,20 +249,21 @@ function transform!(tn::AbstractTensorNetwork, config::SplitSimplification)
         bipartitions = Iterators.flatten(combinations(inds, r) for r in 1:(length(inds)-1))
         for bipartition in bipartitions
             left_inds = collect(bipartition)
-            right_inds = setdiff(inds, left_inds)
 
             # perform an SVD across the bipartition
             u, s, v = svd(tensor; left_inds = left_inds)
-            rank_s = sum(diag(s) .> config.atol)
+            rank_s = sum(s .> config.atol)
 
-            if rank_s < size(s, 1)
+            if rank_s < length(s)
+                hyperindex = only(inds(s))
+
                 # truncate data
-                u = view(u, Tenet.inds(s)[1] => 1:rank_s)
-                s = view(s, (idx -> idx => 1:rank_s).(Tenet.inds(s))...)
-                v = view(v, Tenet.inds(s)[2] => 1:rank_s)
+                u = view(u, hyperindex => 1:rank_s)
+                s = view(s, hyperindex => 1:rank_s)
+                v = view(v, hyperindex => 1:rank_s)
 
                 # replace the original tensor with factorization
-                tensor_l = u * s
+                tensor_l = contract(u, s, dims = Symbol[])
                 tensor_r = v
 
                 push!(tn, dropdims(tensor_l))

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -226,14 +226,16 @@
         tensor = Tensor(data, (:i, :j, :k, :l))
         vidx = [:x, :y]
 
-        # Throw exception if left_inds is not provided
-        @test_throws UndefVarError lu(tensor)
+        # throw if no index is provided
+        @test_throws ArgumentError lu(tensor)
 
-        # Throw exception if left_inds ∉ inds(tensor)
+        # throw if index is not present
         @test_throws ArgumentError lu(tensor, left_inds = (:z,))
+        @test_throws ArgumentError lu(tensor, right_inds = (:z,))
 
-        # throw exception if no right-inds
+        # throw if no inds left
         @test_throws ArgumentError lu(tensor, left_inds = (:i, :j, :k, :l))
+        @test_throws ArgumentError lu(tensor, right_inds = (:i, :j, :k, :l))
 
         # throw if chosen virtual index already present
         @test_throws ArgumentError qr(tensor, left_inds = (:i,), virtualind = :j)

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -222,28 +222,30 @@
     end
 
     @testset "lu" begin
+        using LinearAlgebra: lu
+
         data = rand(2, 2, 2)
         tensor = Tensor(data, (:i, :j, :k))
 
         @testset "[exceptions]" begin
             # Throw exception if left_inds is not provided
             @test_throws ErrorException lu(tensor)
-            # Throw exception if left_inds ∉ labels(tensor)
+            # Throw exception if left_inds ∉ inds(tensor)
             @test_throws ErrorException lu(tensor, (:l,))
             # throw exception if no right-inds
             @test_throws ErrorException lu(tensor, (:i,:j,:k))
         end
 
-        @testset "labels" begin
-            P, L, U = lu(tensor, labels(tensor)[1:2])
-            @test labels(P)[1:2] == labels(tensor)[1:2]
-            @test labels(P)[3:4] == labels(L)[1:2]
-            @test labels(L)[3] == labels(U)[1]
-            @test labels(U)[2] == labels(tensor)[3]
+        @testset "inds" begin
+            P, L, U = lu(tensor, inds(tensor)[1:2])
+            @test inds(P)[1:2] == inds(tensor)[1:2]
+            @test inds(P)[3:4] == inds(L)[1:2]
+            @test inds(L)[3] == inds(U)[1]
+            @test inds(U)[2] == inds(tensor)[3]
         end
 
         @testset "size" begin
-            P, L, U = lu(tensor, labels(tensor)[1:2])
+            P, L, U = lu(tensor, inds(tensor)[1:2])
             @test size(P) == (2, 2, 2, 2)
             @test size(L) == (2, 2, 2)
             @test size(U) == (2, 2)
@@ -251,21 +253,21 @@
             # Additional test with different dimensions
             data2 = rand(2, 4, 6, 8)
             tensor2 = Tensor(data2, (:i, :j, :k, :l))
-            P2, L2, U2 = lu(tensor2, labels(tensor2)[1:2])
+            P2, L2, U2 = lu(tensor2, inds(tensor2)[1:2])
             @test size(P2) == (2, 4, 2, 4)
             @test size(L2) == (2, 4, 8)
             @test size(U2) == (8, 6, 8)
         end
 
         @testset "[accuracy]" begin
-            P, L, U = lu(tensor, labels(tensor)[1:2])
-            tensor_recovered = contract(contract(P, L), U)
+            P, L, U = lu(tensor, inds(tensor)[1:2])
+            tensor_recovered = contract(P, L, U)
             @test tensor_recovered ≈ tensor
 
             data2 = rand(2, 4, 6, 8)
             tensor2 = Tensor(data2, (:i, :j, :k, :l))
-            P2, L2, U2 = lu(tensor2, labels(tensor2)[1:2])
-            tensor2_recovered = contract(contract(P2, L2), U2)
+            P2, L2, U2 = lu(tensor2, inds(tensor2)[1:2])
+            tensor2_recovered = contract(P2, L2, U2)
             @test tensor2_recovered ≈ tensor2
         end
     end


### PR DESCRIPTION
### Summary
This PR adds the new `lu` function for tensors, extending the `LinearAlgebra.lu` function (resolve #26). The new `lu` function returns the LU decomposition of a `Tensor`, where the tensor can be recovered by contracting the permutation tensor `P`, the tensor `L`, and tensor `U`. The tensors `L` and `U` are reshaped versions of the original lower and upper triangular matrices obtained during the decomposition process, respectively.

This implementation is inspired by the LU decomposition in the `scipy` library, as it returns the permutation tensor `P` allowing the original tensor `A` to be recovered with the contraction `A = P * L * U`. This contrasts with `LinearAlgebra`, where the permutation vector `p` is returned, and the original matrix can be recovered with `P' * A = L * U` (where `P'` is the permutation matrix built from `p`).

Please let me know if there are any concerns or issues with extending the `LinearAlgebra` library in this manner.

We have also added tests for this new function.

### Example
A usage example of the lu function:
```julia
julia> using Tenet; using LinearAlgebra; using Test

julia> tensor = Tensor(rand(4, 4, 4), (:i, :j, :k))
4×4×4 Tensor{Float64, 3, Array{Float64, 3}}:
...

julia> P, L, U = lu(tensor, left_inds = labels(tensor)[1:2])
...

julia> @test contract(contract(P, L), U) ≈ tensor
Test Passed
```