### PR TITLE
Enhance `qr` function with `mode` argument

### DIFF
--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -129,7 +129,7 @@ Perform QR factorization on a tensor.
     - `right_inds`: right indices to be used in the QR factorization. Defaults to all indices of `t` except `left_inds`.
     - `virtualind`: name of the virtual bond. Defaults to a random `Symbol`.
 """
-function LinearAlgebra.qr(t::Tensor, mode::Symbol = :reduced; left_inds = (), right_inds = (), virtualind::Symbol = Symbol(uuid4()), kwargs...)    isdisjoint(left_inds, right_inds) ||
+function LinearAlgebra.qr(t::Tensor; left_inds = (), right_inds = (), virtualind::Symbol = Symbol(uuid4()), kwargs...)    isdisjoint(left_inds, right_inds) ||
         throw(ArgumentError("left ($left_inds) and right $(right_inds) indices must be disjoint"))
 
     left_inds, right_inds =

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -119,8 +119,18 @@ end
 
 LinearAlgebra.qr(t::Tensor{<:Any,2}; kwargs...) = Base.@invoke qr(t::Tensor; left_inds = (first(inds(t)),), kwargs...)
 
-function LinearAlgebra.qr(t::Tensor; left_inds = (), right_inds = (), virtualind::Symbol = Symbol(uuid4()), kwargs...)
-    isdisjoint(left_inds, right_inds) ||
+"""
+    LinearAlgebra.qr(t::Tensor, mode::Symbol = :reduced; left_inds = (), right_inds = (), virtualind::Symbol = Symbol(uuid4()), kwargs...
+Perform QR factorization on a tensor.
+# Arguments
+    - `t::Tensor`: tensor to be factorized
+    - `mode::Symbol`: either `:reduced` or `:full`. Defaults to `:reduced`, which will ensure that the dimension of the virtual bond is the minimum of the dimensions of the original tensor.
+# Keyword Arguments
+    - `left_inds`: left indices to be used in the QR factorization. Defaults to all indices of `t` except `right_inds`.
+    - `right_inds`: right indices to be used in the QR factorization. Defaults to all indices of `t` except `left_inds`.
+    - `virtualind`: name of the virtual bond. Defaults to a random `Symbol`.
+"""
+function LinearAlgebra.qr(t::Tensor, mode::Symbol = :reduced; left_inds = (), right_inds = (), virtualind::Symbol = Symbol(uuid4()), kwargs...)    isdisjoint(left_inds, right_inds) ||
         throw(ArgumentError("left ($left_inds) and right $(right_inds) indices must be disjoint"))
 
     left_inds, right_inds =
@@ -138,7 +148,8 @@ function LinearAlgebra.qr(t::Tensor; left_inds = (), right_inds = (), virtualind
     data = reshape(parent(tensor), prod(i -> size(t, i), left_inds), prod(i -> size(t, i), right_inds))
 
     # compute QR
-    Q, R = qr(data; kwargs...)
+    F = qr(data; kwargs...)
+    (mode == :reduced && (Q, R = Matrix(F.Q), Matrix(F.R))) || (mode == :full && (Q, R = F.Q, F.R)) || throw(ArgumentError("mode ($mode) must be either :reduced or :full"))
 
     # tensorify results
     Q = reshape(Q, ([size(t, ind) for ind in left_inds]..., size(Q, 2)))

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -124,7 +124,6 @@ LinearAlgebra.qr(t::Tensor{<:Any,2}; kwargs...) = Base.@invoke qr(t::Tensor; lef
 Perform QR factorization on a tensor.
 # Arguments
     - `t::Tensor`: tensor to be factorized
-    - `mode::Symbol`: either `:reduced` or `:full`. Defaults to `:reduced`, which will ensure that the dimension of the virtual bond is the minimum of the dimensions of the original tensor.
 # Keyword Arguments
     - `left_inds`: left indices to be used in the QR factorization. Defaults to all indices of `t` except `right_inds`.
     - `right_inds`: right indices to be used in the QR factorization. Defaults to all indices of `t` except `left_inds`.
@@ -149,7 +148,7 @@ function LinearAlgebra.qr(t::Tensor, mode::Symbol = :reduced; left_inds = (), ri
 
     # compute QR
     F = qr(data; kwargs...)
-    (mode == :reduced && (Q, R = Matrix(F.Q), Matrix(F.R))) || (mode == :full && (Q, R = F.Q, F.R)) || throw(ArgumentError("mode ($mode) must be either :reduced or :full"))
+    Q, R = Matrix(F.Q), Matrix(F.R)
 
     # tensorify results
     Q = reshape(Q, ([size(t, ind) for ind in left_inds]..., size(Q, 2)))

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -196,7 +196,7 @@
         @testset "size" begin
             Q, R = qr(tensor, left_inds = (:i, :j))
             # Q's new index size = min(prod(left_inds), prod(right_inds)).
-            @test size(Q) == (2, 2, 4)
+            @test size(Q) == (2, 2, 2)
             @test size(R) == (2, 2)
 
             # Additional test with different dimensions


### PR DESCRIPTION
### Summary
Currently, the `qr` decomposition on a `Tensor` t defaults to the "full" mode, which given a matrix `(M, N)` with `M>N` we get a `Q` matrix with size `(M, M)` and `R` with size `(N, N)`. This is counter-intuitive since these two tensors share a virtual index but they do not have the same dimensions. 

In this PR we fix this by adding a `mode` argument to the `qr` function (which by default is set to `:reduced`). With `mode=:reduced`, it will ensure that the dimensions of the virtual index match and with `mode=:full` the `qr` functions returns the full matrices.

### Example of usage
This enhancement facilitates more intuitive operations as illustrated below:
```julia
 julia> using Tenet

 julia> A = Tensor(rand(32, 8), (:i, :j))
32×8 Tensor{Float64, 2, Matrix{Float64}}: ...

julia> Q, R = qr(A, :reduced; left_inds=(:i,))
...

julia> size(Q), size(R)
((32, 8), (8, 8))

julia> Q, R = qr(A, :full; left_inds=(:i,))
...

julia> size(Q), size(R)
((32, 32), (8, 8))
```