### PR TITLE
Implement `@unsafe_region` macro for relaxed tensor operations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Muscle = "21fe5c4b-a943-414d-bf3e-516f24900631"
 OMEinsum = "ebe7aa44-baf0-506c-a96f-8464559b3922"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+ScopedValues = "7e506255-f358-4e82-b7e4-beb19740aa63"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -63,6 +63,24 @@ function Base.isapprox(a::TensorNetwork, b::TensorNetwork; kwargs...)
     end
 end
 
+function __check_index_sizes(tn)
+    # Iterate through each index in the indexmap
+    for (index, tensors) in tn.indexmap
+        # Get the size of the first tensor for this index
+        reference_size = size(tensors[1], index)
+
+        # Compare the size of each subsequent tensor for this index
+        for tensor in tensors
+            if size(tensor, index) != reference_size
+                throw(DimensionMismatch("Inconsistent size for index $index."))
+                return false
+            end
+        end
+    end
+
+    return true
+end
+
 """
     tensors(tn::TensorNetwork)
 

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -227,7 +227,7 @@ end
 const is_unsafe_region = ScopedValue(false) # global ScopedValue for the unsafe region
 
 macro unsafe_region(tn, block)
-    quote
+    return esc(quote
         local old = copy($tn)
         try
             $with($is_unsafe_region => true) do
@@ -239,7 +239,7 @@ macro unsafe_region(tn, block)
                 throw(DimensionMismatch("Inconsistent size of indices"))
             end
         end
-    end |> esc
+    end)
 end
 
 """
@@ -255,7 +255,9 @@ function Base.push!(tn::TensorNetwork, tensor::Tensor)
     # Only check index sizes if we are not in an unsafe region
     if !is_unsafe_region[]
         for i in Iterators.filter(i -> size(tn, i) != size(tensor, i), inds(tensor) ∩ inds(tn))
-        throw(DimensionMismatch("size(tensor,$i)=$(size(tensor,i)) but should be equal to size(tn,$i)=$(size(tn,i))"))
+            throw(
+                DimensionMismatch("size(tensor,$i)=$(size(tensor,i)) but should be equal to size(tn,$i)=$(size(tn,i))")
+            )
         end
     end
 

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -249,9 +249,11 @@ See also: [`append!`](@ref), [`pop!`](@ref).
 function Base.push!(tn::TensorNetwork, tensor::Tensor)
     tensor ∈ keys(tn.tensormap) && return tn
 
-    # check index sizes
-    for i in Iterators.filter(i -> size(tn, i) != size(tensor, i), inds(tensor) ∩ inds(tn))
+    # Only check index sizes if we are not in an unsafe region
+    if !is_unsafe_region[]
+        for i in Iterators.filter(i -> size(tn, i) != size(tensor, i), inds(tensor) ∩ inds(tn))
         throw(DimensionMismatch("size(tensor,$i)=$(size(tensor,i)) but should be equal to size(tn,$i)=$(size(tn,i))"))
+        end
     end
 
     tn.tensormap[tensor] = collect(inds(tensor))

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -224,6 +224,21 @@ function neighbors(tn::TensorNetwork, i::Symbol; open::Bool=true)
     return tensors
 end
 
+const is_unsafe_region = Ref(false) # global ScopedValue for the unsafe region
+
+macro unsafe_region(tn, block)
+    quote
+        local old_is_unsafe = $is_unsafe_region[]
+        $is_unsafe_region[] = true
+        try
+            $block
+        finally
+            $is_unsafe_region[] = old_is_unsafe
+            Tenet.__check_index_sizes($tn)
+        end
+    end |> esc
+end
+
 """
     push!(tn::TensorNetwork, tensor::Tensor)
 

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -227,19 +227,21 @@ end
 const is_unsafe_region = ScopedValue(false) # global ScopedValue for the unsafe region
 
 macro unsafe_region(tn, block)
-    return esc(quote
-        local old = copy($tn)
-        try
-            $with($is_unsafe_region => true) do
-                $block
+    return esc(
+        quote
+            local old = copy($tn)
+            try
+                $with($is_unsafe_region => true) do
+                    $block
+                end
+            finally
+                if !Tenet.__check_index_sizes($tn)
+                    tn = old
+                    throw(DimensionMismatch("Inconsistent size of indices"))
+                end
             end
-        finally
-            if !Tenet.__check_index_sizes($tn)
-                tn = old
-                throw(DimensionMismatch("Inconsistent size of indices"))
-            end
-        end
-    end)
+        end,
+    )
 end
 
 """

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -361,10 +361,12 @@
 
         @testset "unsafe region" begin
             tn = TensorNetwork([Tensor(ones(2, 2), [:a, :b]), Tensor(ones(2, 2), [:b, :c])])
+            tn_copy = copy(tn)
             @test_throws DimensionMismatch Tenet.@unsafe_region tn begin
                 tensor = Tensor(ones(3, 2), [:c, :d])
                 push!(tn, tensor)
             end
+            @test tn == tn_copy
 
             Tenet.@unsafe_region tn begin
                 tensor = Tensor(ones(3, 2), [:c, :d])

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -347,4 +347,47 @@
             end
         end
     end
+
+    @testset "@unsafe_region" begin
+        @testset "safe region" begin
+            tn = TensorNetwork([Tensor(ones(2, 2), [:a, :b]), Tensor(ones(2, 2), [:b, :c])])
+            Tenet.@unsafe_region tn begin
+                tensor = Tensor(ones(2, 2), [:c, :d])
+                push!(tn, tensor)
+                @test length(tensors(tn)) == 3
+            end
+            @test length(tensors(tn)) == 3
+        end
+
+        @testset "unsafe region" begin
+            tn = TensorNetwork([Tensor(ones(2, 2), [:a, :b]), Tensor(ones(2, 2), [:b, :c])])
+            @test_throws DimensionMismatch Tenet.@unsafe_region tn begin
+                tensor = Tensor(ones(3, 2), [:c, :d])
+                push!(tn, tensor)
+                @test length(tensors(tn)) == 3
+            end
+
+            Tenet.@unsafe_region tn begin
+                tensor = Tensor(ones(3, 2), [:c, :d])
+                push!(tn, tensor)
+                @test length(tensors(tn)) == 3
+                pop!(tn, tensor)
+            end
+
+            @testset "SubArray" begin
+                a = Tensor(view(ones(2, 2), 1:2, 1:2), [:a, :b])
+                b = Tensor(view(ones(2, 2), 1:2, 1:2), [:b, :c])
+                c = Tensor(view(ones(3, 2), 1:3, 1:2), [:c, :d])
+                tn = TensorNetwork([a, b])
+
+                @test_throws DimensionMismatch Tenet.@unsafe_region tn begin
+                    push!(tn, c)
+                    @test length(tensors(tn)) == 3
+                end
+
+                @test tensors(tn)[1] === a
+                @test tensors(tn)[2] === b
+            end
+        end
+    end
 end

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -364,7 +364,6 @@
             @test_throws DimensionMismatch Tenet.@unsafe_region tn begin
                 tensor = Tensor(ones(3, 2), [:c, :d])
                 push!(tn, tensor)
-                @test length(tensors(tn)) == 3
             end
 
             Tenet.@unsafe_region tn begin
@@ -382,7 +381,6 @@
 
                 @test_throws DimensionMismatch Tenet.@unsafe_region tn begin
                     push!(tn, c)
-                    @test length(tensors(tn)) == 3
                 end
 
                 @test tensors(tn)[1] === a


### PR DESCRIPTION
This PR resolves issue #147 by introducing a new macro `@unsafe_region`, allowing users to temporarily relax index size checks when performing tensor operations within a specified code block. This feature is particularly useful for updating tensors in a tensor network where intermediate steps might involve tensors with mismatched sizes.

### Example usage
```julia
julia> using Tenet

julia> tn = TensorNetwork([
           Tensor(rand(2, 2, 2), [:i, :j, :k]),
           Tensor(rand(2, 2), [:j, :l]),
           Tensor(rand(2, 2, 2, 2), [:l, :k, :m, :n]),
           Tensor(rand(2, 2, 2), [:n, :o, :p])])
TensorNetwork (#tensors=4, #inds=8)

julia> a = Tensor(rand(3, 2), (:i, :j)); push!(tn, a)
ERROR: DimensionMismatch: size(tensor,i)=3 but should be equal to size(tn,i)=2
Stacktrace:
 [1] push!(tn::TensorNetwork, tensor::Tensor{Float64, 2, Matrix{Float64}})
   @ Tenet ~/git/Tenet.jl/src/TensorNetwork.jl:255
 [2] top-level scope
   @ REPL[11]:1

julia> Tenet.@unsafe_region tn begin
           a = Tensor(rand(3, 2), (:i, :j))
           push!(tn, a)
           pop!(tn, a)
       end
3×2 Tensor{Float64, 2, Matrix{Float64}}:
 0.638985  0.725609
 0.850249  0.315764
 0.141707  0.642034
```