### PR TITLE
Extend `evolve` of an `MPS` with an `MPO`

### DIFF
--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -726,9 +726,9 @@ function evolve!(ψ::Chain, mpo::Chain)
 
     Tenet.@unsafe_region ψ begin
         for i in 1:L
-            contractedind = inds(ψ; at = Site(i))
-            t = contract(tensors(ψ; at = Site(i)), tensors(mpo; at = Site(i)); dims = (contractedind,))
-            physicalind = inds(mpo; at = Site(i))
+            contractedind = inds(ψ; at=Site(i))
+            t = contract(tensors(ψ; at=Site(i)), tensors(mpo; at=Site(i)); dims=(contractedind,))
+            physicalind = inds(mpo; at=Site(i))
 
             # Fuse the two right legs of t into one
             if i == 1
@@ -756,13 +756,13 @@ function evolve!(ψ::Chain, mpo::Chain)
                 new_inds,
             )
 
-            replace!(TensorNetwork(ψ), tensors(ψ; at = Site(i)) => t)
+            replace!(TensorNetwork(ψ), tensors(ψ; at=Site(i)) => t)
 
             if i < L
                 d = size(TensorNetwork(mpo), rightindex(mpo, Site(i)))
-                Λᵢ = tensors(ψ; between = (Site(i), Site(i + 1)))
+                Λᵢ = tensors(ψ; between=(Site(i), Site(i + 1)))
                 Λᵢ = Tensor(diag(kron(Matrix(LinearAlgebra.I, d, d), diagm(parent(Λᵢ)))), inds(Λᵢ))
-                replace!(TensorNetwork(ψ), tensors(ψ; between = (Site(i), Site(i + 1))) => Λᵢ)
+                replace!(TensorNetwork(ψ), tensors(ψ; between=(Site(i), Site(i + 1))) => Λᵢ)
             end
         end
     end


### PR DESCRIPTION
### Summary
This PR was left open in the legacy code in `Qrochet` ([#35](https://github.com/bsc-quantic/Qrochet.jl/pull/35)). This PR extends the `evolve` function, which evolves a Matrix Product State (`MPS`) using a Matrix Product Operator (`MPO`). The idea from @starsfordummies is that we `contract` the tensors of each corresponding `site`, and we then create the new `λ` with a kron product with the old `λ` (which come from the `MPS`) and the identity (comes from the `MPO`). Right now, this function only works for mps in the canonical form.

### Example
Here we show how can we use this function:

```julia
julia> using Tenet

julia> ψ = rand(Chain, Open, State; n=8, χ=10); canonize!(ψ)
MPS (inputs=0, outputs=8)

julia> mpo = rand(Chain, Open, Operator; n=8, χ=10)
MPO (inputs=8, outputs=8)

julia> Tenet.@reindex! inputs(mpo) => outputs(ψ)
MPS (inputs=0, outputs=8)

julia> ψ = Tenet.evolve(ψ, mpo)
MPS (inputs=0, outputs=8)

julia> size.(tensors(ψ))
15-element Vector{Tuple{Int64, Vararg{Int64}}}:
 (8,)
 (40,)
 (80,)
 (100,)
 (80,)
 (40,)
 (8,)
 (2, 8)
 (2, 8, 40)
 (2, 40, 80)
 (2, 80, 100)
 (2, 100, 80)
 (2, 80, 40)
 (2, 40, 8)
 (2, 8)
```