### PR TITLE
Replace the global index counter generator for a local data structure

### DIFF
--- a/ext/TenetChainRulesCoreExt/non_diff.jl
+++ b/ext/TenetChainRulesCoreExt/non_diff.jl
@@ -10,9 +10,9 @@
 # TODO maybe we need to convert this into a frule/rrule? such that the tangents change their indices too
 @non_differentiable Base.replace!(::TensorNetwork, ::Pair{Symbol,Symbol}...)
 
-@non_differentiable Tenet.currindex(args...; kwargs...)
-@non_differentiable Tenet.nextindex!(args...; kwargs...)
-@non_differentiable Tenet.resetindex!(args...; kwargs...)
+@non_differentiable Tenet.currindex(::Tenet.IndexCounter)
+@non_differentiable Tenet.nextindex!(::Tenet.IndexCounter)
+@non_differentiable Tenet.resetindex!(::Tenet.IndexCounter)
 
 # WARN type-piracy
 @non_differentiable Base.setdiff(::Vector{Symbol}, ::Base.ValueIterator)

--- a/ext/TenetChainRulesCoreExt/non_diff.jl
+++ b/ext/TenetChainRulesCoreExt/non_diff.jl
@@ -10,8 +10,9 @@
 # TODO maybe we need to convert this into a frule/rrule? such that the tangents change their indices too
 @non_differentiable Base.replace!(::TensorNetwork, ::Pair{Symbol,Symbol}...)
 
-@non_differentiable Tenet.currindex()
-@non_differentiable Tenet.nextindex()
+@non_differentiable Tenet.currindex(args...; kwargs...)
+@non_differentiable Tenet.nextindex(args...; kwargs...)
+@non_differentiable Tenet.resetindex(args...; kwargs...)
 
 # WARN type-piracy
 @non_differentiable Base.setdiff(::Vector{Symbol}, ::Base.ValueIterator)

--- a/ext/TenetChainRulesCoreExt/non_diff.jl
+++ b/ext/TenetChainRulesCoreExt/non_diff.jl
@@ -11,7 +11,7 @@
 @non_differentiable Base.replace!(::TensorNetwork, ::Pair{Symbol,Symbol}...)
 
 @non_differentiable Tenet.currindex(args...; kwargs...)
-@non_differentiable Tenet.nextindex(args...; kwargs...)
+@non_differentiable Tenet.nextindex!(args...; kwargs...)
 @non_differentiable Tenet.resetindex!(args...; kwargs...)
 
 # WARN type-piracy

--- a/ext/TenetChainRulesCoreExt/non_diff.jl
+++ b/ext/TenetChainRulesCoreExt/non_diff.jl
@@ -12,7 +12,7 @@
 
 @non_differentiable Tenet.currindex(args...; kwargs...)
 @non_differentiable Tenet.nextindex(args...; kwargs...)
-@non_differentiable Tenet.resetindex(args...; kwargs...)
+@non_differentiable Tenet.resetindex!(args...; kwargs...)
 
 # WARN type-piracy
 @non_differentiable Base.setdiff(::Vector{Symbol}, ::Base.ValueIterator)

--- a/ext/TenetQuacExt.jl
+++ b/ext/TenetQuacExt.jl
@@ -1,7 +1,6 @@
 module TenetQuacExt
 
 using Tenet
-using Tenet
 using Quac: Gate, Circuit, lanes, arraytype, Swap
 
 function Tenet.Dense(gate::Gate)
@@ -14,7 +13,9 @@ Tenet.evolve!(qtn::Ansatz, gate::Gate; kwargs...) = evolve!(qtn, Tenet.Dense(gat
 
 function Tenet.Quantum(circuit::Circuit)
     n = lanes(circuit)
-    wire = [[Tenet.nextindex()] for _ in 1:n]
+    gen = Tenet.IndexCounter()
+
+    wire = [[Tenet.nextindex(gen)] for _ in 1:n]
     tensors = Tensor[]
 
     for gate in circuit
@@ -29,7 +30,7 @@ function Tenet.Quantum(circuit::Circuit)
 
         inds = (x -> collect(Iterators.flatten(zip(x...))))(
             map(lanes(gate)) do l
-                from, to = last(wire[l]), Tenet.nextindex()
+                from, to = last(wire[l]), Tenet.nextindex(gen)
                 push!(wire[l], to)
                 (from, to)
             end,

--- a/ext/TenetQuacExt.jl
+++ b/ext/TenetQuacExt.jl
@@ -15,7 +15,7 @@ function Tenet.Quantum(circuit::Circuit)
     n = lanes(circuit)
     gen = Tenet.IndexCounter()
 
-    wire = [[Tenet.nextindex(gen)] for _ in 1:n]
+    wire = [[Tenet.nextindex!(gen)] for _ in 1:n]
     tensors = Tensor[]
 
     for gate in circuit
@@ -30,7 +30,7 @@ function Tenet.Quantum(circuit::Circuit)
 
         inds = (x -> collect(Iterators.flatten(zip(x...))))(
             map(lanes(gate)) do l
-                from, to = last(wire[l]), Tenet.nextindex(gen)
+                from, to = last(wire[l]), Tenet.nextindex!(gen)
                 push!(wire[l], to)
                 (from, to)
             end,

--- a/ext/TenetYaoExt.jl
+++ b/ext/TenetYaoExt.jl
@@ -15,7 +15,8 @@ function Tenet.Quantum(circuit::AbstractBlock)
     @assert nlevel(circuit) == 2 "Only support 2-level qubits"
 
     n = nqubits(circuit)
-    wire = [[Tenet.nextindex()] for _ in 1:n]
+    gen = Tenet.IndexCounter()
+    wire = [[Tenet.nextindex(gen)] for _ in 1:n]
     tensors = Tensor[]
 
     for gate in flatten_circuit(circuit)
@@ -30,7 +31,7 @@ function Tenet.Quantum(circuit::AbstractBlock)
 
         inds = (x -> collect(Iterators.flatten(zip(x...))))(
             map(occupied_locs(gate)) do l
-                from, to = last(wire[l]), Tenet.nextindex()
+                from, to = last(wire[l]), Tenet.nextindex(gen)
                 push!(wire[l], to)
                 (from, to)
             end,

--- a/ext/TenetYaoExt.jl
+++ b/ext/TenetYaoExt.jl
@@ -16,7 +16,7 @@ function Tenet.Quantum(circuit::AbstractBlock)
 
     n = nqubits(circuit)
     gen = Tenet.IndexCounter()
-    wire = [[Tenet.nextindex(gen)] for _ in 1:n]
+    wire = [[Tenet.nextindex!(gen)] for _ in 1:n]
     tensors = Tensor[]
 
     for gate in flatten_circuit(circuit)
@@ -31,7 +31,7 @@ function Tenet.Quantum(circuit::AbstractBlock)
 
         inds = (x -> collect(Iterators.flatten(zip(x...))))(
             map(occupied_locs(gate)) do l
-                from, to = last(wire[l]), Tenet.nextindex(gen)
+                from, to = last(wire[l]), Tenet.nextindex!(gen)
                 push!(wire[l], to)
                 (from, to)
             end,

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -39,7 +39,7 @@ function Chain(::State, boundary::Periodic, arrays::Vector{<:AbstractArray}; ord
 
     n = length(arrays)
     gen = IndexCounter()
-    symbols = [nextindex(gen) for _ in 1:(2n)]
+    symbols = [nextindex!(gen) for _ in 1:(2n)]
 
     _tensors = map(enumerate(arrays)) do (i, array)
         inds = map(order) do dir
@@ -70,7 +70,7 @@ function Chain(::State, boundary::Open, arrays::Vector{<:AbstractArray}; order=d
 
     n = length(arrays)
     gen = IndexCounter()
-    symbols = [nextindex(gen) for _ in 1:(2n)]
+    symbols = [nextindex!(gen) for _ in 1:(2n)]
 
     _tensors = map(enumerate(arrays)) do (i, array)
         _order = if i == 1
@@ -107,7 +107,7 @@ function Chain(::Operator, boundary::Periodic, arrays::Vector{<:AbstractArray}; 
 
     n = length(arrays)
     gen = IndexCounter()
-    symbols = [nextindex(gen) for _ in 1:(3n)]
+    symbols = [nextindex!(gen) for _ in 1:(3n)]
 
     _tensors = map(enumerate(arrays)) do (i, array)
         inds = map(order) do dir
@@ -141,7 +141,7 @@ function Chain(::Operator, boundary::Open, arrays::Vector{<:AbstractArray}; orde
 
     n = length(arrays)
     gen = IndexCounter()
-    symbols = [nextindex(gen) for _ in 1:(3n - 1)]
+    symbols = [nextindex!(gen) for _ in 1:(3n - 1)]
 
     _tensors = map(enumerate(arrays)) do (i, array)
         _order = if i == 1

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -38,7 +38,8 @@ function Chain(::State, boundary::Periodic, arrays::Vector{<:AbstractArray}; ord
         throw(ArgumentError("order must be a permutation of $(String.(defaultorder(State())))"))
 
     n = length(arrays)
-    symbols = [nextindex() for _ in 1:(2n)]
+    gen = IndexCounter()
+    symbols = [nextindex(gen) for _ in 1:(2n)]
 
     _tensors = map(enumerate(arrays)) do (i, array)
         inds = map(order) do dir
@@ -68,7 +69,8 @@ function Chain(::State, boundary::Open, arrays::Vector{<:AbstractArray}; order=d
         throw(ArgumentError("order must be a permutation of $(String.(defaultorder(Chain, State())))"))
 
     n = length(arrays)
-    symbols = [nextindex() for _ in 1:(2n)]
+    gen = IndexCounter()
+    symbols = [nextindex(gen) for _ in 1:(2n)]
 
     _tensors = map(enumerate(arrays)) do (i, array)
         _order = if i == 1
@@ -104,7 +106,8 @@ function Chain(::Operator, boundary::Periodic, arrays::Vector{<:AbstractArray}; 
         throw(ArgumentError("order must be a permutation of $(String.(defaultorder(Chain, Operator())))"))
 
     n = length(arrays)
-    symbols = [nextindex() for _ in 1:(3n)]
+    gen = IndexCounter()
+    symbols = [nextindex(gen) for _ in 1:(3n)]
 
     _tensors = map(enumerate(arrays)) do (i, array)
         inds = map(order) do dir
@@ -137,7 +140,8 @@ function Chain(::Operator, boundary::Open, arrays::Vector{<:AbstractArray}; orde
         throw(ArgumentError("order must be a permutation of $(String.(defaultorder(Chain, Operator())))"))
 
     n = length(arrays)
-    symbols = [nextindex() for _ in 1:(3n - 1)]
+    gen = IndexCounter()
+    symbols = [nextindex(gen) for _ in 1:(3n - 1)]
 
     _tensors = map(enumerate(arrays)) do (i, array)
         _order = if i == 1

--- a/src/Ansatz/Dense.jl
+++ b/src/Ansatz/Dense.jl
@@ -6,7 +6,8 @@ function Dense(::State, array::AbstractArray; sites=Site.(1:ndims(array)))
     @assert ndims(array) > 0
     @assert all(>(1), size(array))
 
-    symbols = [nextindex() for _ in 1:ndims(array)]
+    gen = IndexCounter()
+    symbols = [nextindex(gen) for _ in 1:ndims(array)]
     sitemap = Dict{Site,Symbol}(
         map(sites, 1:ndims(array)) do site, i
             site => symbols[i]
@@ -25,7 +26,8 @@ function Dense(::Operator, array::AbstractArray; sites)
     @assert all(>(1), size(array))
     @assert length(sites) == ndims(array)
 
-    tensor_inds = [nextindex() for _ in 1:ndims(array)]
+    gen = IndexCounter()
+    tensor_inds = [nextindex(gen) for _ in 1:ndims(array)]
     tensor = Tensor(array, tensor_inds)
     tn = TensorNetwork([tensor])
 

--- a/src/Ansatz/Dense.jl
+++ b/src/Ansatz/Dense.jl
@@ -7,7 +7,7 @@ function Dense(::State, array::AbstractArray; sites=Site.(1:ndims(array)))
     @assert all(>(1), size(array))
 
     gen = IndexCounter()
-    symbols = [nextindex(gen) for _ in 1:ndims(array)]
+    symbols = [nextindex!(gen) for _ in 1:ndims(array)]
     sitemap = Dict{Site,Symbol}(
         map(sites, 1:ndims(array)) do site, i
             site => symbols[i]
@@ -27,7 +27,7 @@ function Dense(::Operator, array::AbstractArray; sites)
     @assert length(sites) == ndims(array)
 
     gen = IndexCounter()
-    tensor_inds = [nextindex(gen) for _ in 1:ndims(array)]
+    tensor_inds = [nextindex!(gen) for _ in 1:ndims(array)]
     tensor = Tensor(array, tensor_inds)
     tn = TensorNetwork([tensor])
 

--- a/src/Ansatz/Grid.jl
+++ b/src/Ansatz/Grid.jl
@@ -23,9 +23,9 @@ function Grid(::State, ::Periodic, arrays::Matrix{<:AbstractArray})
 
     m, n = size(arrays)
     gen = IndexCounter()
-    pinds = map(_ -> nextindex(gen), arrays)
-    hvinds = map(_ -> nextindex(gen), arrays)
-    vvinds = map(_ -> nextindex(gen), arrays)
+    pinds = map(_ -> nextindex!(gen), arrays)
+    hvinds = map(_ -> nextindex!(gen), arrays)
+    vvinds = map(_ -> nextindex!(gen), arrays)
 
     _tensors = map(eachindex(IndexCartesian(), arrays)) do I
         i, j = Tuple(I)
@@ -63,9 +63,9 @@ function Grid(::State, ::Open, arrays::Matrix{<:AbstractArray})
     end
 
     gen = IndexCounter()
-    pinds = map(_ -> nextindex(gen), arrays)
-    vvinds = [nextindex(gen) for _ in 1:(m - 1), _ in 1:n]
-    hvinds = [nextindex(gen) for _ in 1:m, _ in 1:(n - 1)]
+    pinds = map(_ -> nextindex!(gen), arrays)
+    vvinds = [nextindex!(gen) for _ in 1:(m - 1), _ in 1:n]
+    hvinds = [nextindex!(gen) for _ in 1:m, _ in 1:(n - 1)]
 
     _tensors = map(eachindex(IndexCartesian(), arrays)) do I
         i, j = Tuple(I)
@@ -91,10 +91,10 @@ function Grid(::Operator, ::Periodic, arrays::Matrix{<:AbstractArray})
 
     m, n = size(arrays)
     gen = IndexCounter()
-    ipinds = map(_ -> nextindex(gen), arrays)
-    opinds = map(_ -> nextindex(gen), arrays)
-    hvinds = map(_ -> nextindex(gen), arrays)
-    vvinds = map(_ -> nextindex(gen), arrays)
+    ipinds = map(_ -> nextindex!(gen), arrays)
+    opinds = map(_ -> nextindex!(gen), arrays)
+    hvinds = map(_ -> nextindex!(gen), arrays)
+    vvinds = map(_ -> nextindex!(gen), arrays)
 
     _tensors = map(eachindex(IndexCartesian(), arrays)) do I
         i, j = Tuple(I)
@@ -137,10 +137,10 @@ function Grid(::Operator, ::Open, arrays::Matrix{<:AbstractArray})
     end
 
     gen = IndexCounter()
-    ipinds = map(_ -> nextindex(gen), arrays)
-    opinds = map(_ -> nextindex(gen), arrays)
-    vvinds = [nextindex(gen) for _ in 1:(m - 1), _ in 1:n]
-    hvinds = [nextindex(gen) for _ in 1:m, _ in 1:(n - 1)]
+    ipinds = map(_ -> nextindex!(gen), arrays)
+    opinds = map(_ -> nextindex!(gen), arrays)
+    vvinds = [nextindex!(gen) for _ in 1:(m - 1), _ in 1:n]
+    hvinds = [nextindex!(gen) for _ in 1:m, _ in 1:(n - 1)]
 
     _tensors = map(eachindex(IndexCartesian(), arrays)) do I
         i, j = Tuple(I)

--- a/src/Ansatz/Grid.jl
+++ b/src/Ansatz/Grid.jl
@@ -22,9 +22,10 @@ function Grid(::State, ::Periodic, arrays::Matrix{<:AbstractArray})
     @assert all(==(4) ∘ ndims, arrays) "All arrays must have 4 dimensions"
 
     m, n = size(arrays)
-    pinds = map(_ -> nextindex(), arrays)
-    hvinds = map(_ -> nextindex(), arrays)
-    vvinds = map(_ -> nextindex(), arrays)
+    gen = IndexCounter()
+    pinds = map(_ -> nextindex(gen), arrays)
+    hvinds = map(_ -> nextindex(gen), arrays)
+    vvinds = map(_ -> nextindex(gen), arrays)
 
     _tensors = map(eachindex(IndexCartesian(), arrays)) do I
         i, j = Tuple(I)
@@ -61,9 +62,10 @@ function Grid(::State, ::Open, arrays::Matrix{<:AbstractArray})
         throw(DimensionMismatch())
     end
 
-    pinds = map(_ -> nextindex(), arrays)
-    vvinds = [nextindex() for _ in 1:(m - 1), _ in 1:n]
-    hvinds = [nextindex() for _ in 1:m, _ in 1:(n - 1)]
+    gen = IndexCounter()
+    pinds = map(_ -> nextindex(gen), arrays)
+    vvinds = [nextindex(gen) for _ in 1:(m - 1), _ in 1:n]
+    hvinds = [nextindex(gen) for _ in 1:m, _ in 1:(n - 1)]
 
     _tensors = map(eachindex(IndexCartesian(), arrays)) do I
         i, j = Tuple(I)
@@ -88,10 +90,11 @@ function Grid(::Operator, ::Periodic, arrays::Matrix{<:AbstractArray})
     @assert all(==(4) ∘ ndims, arrays) "All arrays must have 4 dimensions"
 
     m, n = size(arrays)
-    ipinds = map(_ -> nextindex(), arrays)
-    opinds = map(_ -> nextindex(), arrays)
-    hvinds = map(_ -> nextindex(), arrays)
-    vvinds = map(_ -> nextindex(), arrays)
+    gen = IndexCounter()
+    ipinds = map(_ -> nextindex(gen), arrays)
+    opinds = map(_ -> nextindex(gen), arrays)
+    hvinds = map(_ -> nextindex(gen), arrays)
+    vvinds = map(_ -> nextindex(gen), arrays)
 
     _tensors = map(eachindex(IndexCartesian(), arrays)) do I
         i, j = Tuple(I)
@@ -133,10 +136,11 @@ function Grid(::Operator, ::Open, arrays::Matrix{<:AbstractArray})
         throw(DimensionMismatch())
     end
 
-    ipinds = map(_ -> nextindex(), arrays)
-    opinds = map(_ -> nextindex(), arrays)
-    vvinds = [nextindex() for _ in 1:(m - 1), _ in 1:n]
-    hvinds = [nextindex() for _ in 1:m, _ in 1:(n - 1)]
+    gen = IndexCounter()
+    ipinds = map(_ -> nextindex(gen), arrays)
+    opinds = map(_ -> nextindex(gen), arrays)
+    vvinds = [nextindex(gen) for _ in 1:(m - 1), _ in 1:n]
+    hvinds = [nextindex(gen) for _ in 1:m, _ in 1:(n - 1)]
 
     _tensors = map(eachindex(IndexCartesian(), arrays)) do I
         i, j = Tuple(I)

--- a/src/Ansatz/Product.jl
+++ b/src/Ansatz/Product.jl
@@ -19,7 +19,7 @@ Product(arrays::Vector{<:AbstractMatrix}) = Product(Operator(), Open(), arrays)
 
 function Product(::State, ::Open, arrays)
     gen = IndexCounter()
-    symbols = [nextindex(gen) for _ in 1:length(arrays)]
+    symbols = [nextindex!(gen) for _ in 1:length(arrays)]
     _tensors = map(enumerate(arrays)) do (i, array)
         Tensor(array, [symbols[i]])
     end
@@ -32,7 +32,7 @@ end
 function Product(::Operator, ::Open, arrays)
     n = length(arrays)
     gen = IndexCounter()
-    symbols = [nextindex(gen) for _ in 1:(2 * length(arrays))]
+    symbols = [nextindex!(gen) for _ in 1:(2 * length(arrays))]
     _tensors = map(enumerate(arrays)) do (i, array)
         Tensor(array, [symbols[i + n], symbols[i]])
     end

--- a/src/Ansatz/Product.jl
+++ b/src/Ansatz/Product.jl
@@ -18,7 +18,8 @@ Product(arrays::Vector{<:AbstractVector}) = Product(State(), Open(), arrays)
 Product(arrays::Vector{<:AbstractMatrix}) = Product(Operator(), Open(), arrays)
 
 function Product(::State, ::Open, arrays)
-    symbols = [nextindex() for _ in 1:length(arrays)]
+    gen = IndexCounter()
+    symbols = [nextindex(gen) for _ in 1:length(arrays)]
     _tensors = map(enumerate(arrays)) do (i, array)
         Tensor(array, [symbols[i]])
     end
@@ -30,7 +31,8 @@ end
 
 function Product(::Operator, ::Open, arrays)
     n = length(arrays)
-    symbols = [nextindex() for _ in 1:(2 * length(arrays))]
+    gen = IndexCounter()
+    symbols = [nextindex(gen) for _ in 1:(2 * length(arrays))]
     _tensors = map(enumerate(arrays)) do (i, array)
         Tensor(array, [symbols[i + n], symbols[i]])
     end

--- a/src/Helpers.jl
+++ b/src/Helpers.jl
@@ -73,6 +73,9 @@ end
 
 currindex(gen::IndexCounter) = letter(gen.counter[])
 function nextindex(gen::IndexCounter)
-    return (gen.counter.value >= 135000) ? resetindex() : letter(Threads.atomic_add!(gen.counter, 1))
+    if gen.counter.value >= 135000
+        throw(ErrorException("run-out of indices!"))
+    end
+    return letter(Threads.atomic_add!(gen.counter, 1))
 end
-resetindex(gen::IndexCounter) = letter(Threads.atomic_xchg!(gen.counter, 1))
+resetindex!(gen::IndexCounter) = letter(Threads.atomic_xchg!(gen.counter, 1))

--- a/src/Helpers.jl
+++ b/src/Helpers.jl
@@ -65,8 +65,14 @@ function nonunique(x)
     return unique(x[nonuniqueindexes])
 end
 
-const __indexcounter::Threads.Atomic{Int} = Threads.Atomic{Int}(1)
+struct IndexCounter
+    counter::Threads.Atomic{Int}
 
-currindex() = letter(__indexcounter[])
-nextindex() = (__indexcounter.value >= 135000) ? resetindex() : letter(Threads.atomic_add!(__indexcounter, 1))
-resetindex() = letter(Threads.atomic_xchg!(__indexcounter, 1))
+    IndexCounter(init::Int=1) = new(Threads.Atomic{Int}(init))
+end
+
+currindex(gen::IndexCounter) = letter(gen.counter[])
+function nextindex(gen::IndexCounter)
+    return (gen.counter.value >= 135000) ? resetindex() : letter(Threads.atomic_add!(gen.counter, 1))
+end
+resetindex(gen::IndexCounter) = letter(Threads.atomic_xchg!(gen.counter, 1))

--- a/src/Helpers.jl
+++ b/src/Helpers.jl
@@ -72,7 +72,7 @@ struct IndexCounter
 end
 
 currindex(gen::IndexCounter) = letter(gen.counter[])
-function nextindex(gen::IndexCounter)
+function nextindex!(gen::IndexCounter)
     if gen.counter.value >= 135000
         throw(ErrorException("run-out of indices!"))
     end

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -193,7 +193,7 @@ ninds(tn::TensorNetwork) = length(tn.indexmap)
 
 function resetindex!(tn::TensorNetwork)
     gen = IndexCounter()
-    mapping = Dict{Symbol,Symbol}([i => nextindex(gen) for i in inds(tn)])
+    mapping = Dict{Symbol,Symbol}([i => nextindex!(gen) for i in inds(tn)])
     return replace!(tn, mapping)
 end
 

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -191,6 +191,12 @@ See also: [`ntensors`](@ref)
 """
 ninds(tn::TensorNetwork) = length(tn.indexmap)
 
+function resetindex!(tn::TensorNetwork)
+    gen = IndexCounter()
+    mapping = Dict{Symbol,Symbol}([i => nextindex(gen) for i in inds(tn)])
+    return replace!(tn, mapping)
+end
+
 """
     size(tn::TensorNetwork)
     size(tn::TensorNetwork, index)


### PR DESCRIPTION
There have been reports that when generating too many indices automatically (using the atomic counter) in the same Julia session, it breaks.

This usually happens due to repeatedly generating `TensorNetworks`.

This PR fixes it by introducing `IndexCounter`: a small wrapper over the currently global behaviour.
If merged, all `TensorNetwork`s would start from the same index.
