### PR TITLE
Extend `KrylovKit.eigsolve` by allowing the initial guess x₀ to be a `Tensor`

### DIFF
--- a/test/integration/KrylovKit_test.jl
+++ b/test/integration/KrylovKit_test.jl
@@ -55,8 +55,24 @@
     @test parent(reconstructed_tensor) ≈ parent(transpose(reconstructed_tensor_perm))
 
     @testset "Lanczos" begin
-        vals_lanczos, vecs_lanczos = eigsolve(
-            tensor, rand(ComplexF64, 4), 1, :SR, Lanczos(; krylovdim=2, tol=1e-16); left_inds=[:i], right_inds=[:j]
+        @test_throws ArgumentError eigsolve(
+            tensor,
+            Tensor(rand(ComplexF64, 4), (:j,)),
+            1,
+            :SR,
+            Lanczos(; krylovdim=2, tol=1e-16);
+            left_inds=[:i],
+            right_inds=[:j],
+        )
+
+        vals_lanczos, vecs_lanczos, info = eigsolve(
+            tensor,
+            Tensor(rand(ComplexF64, 4), (:i,)),
+            1,
+            :SR,
+            Lanczos(; krylovdim=2, tol=1e-16);
+            left_inds=[:i],
+            right_inds=[:j],
         )
 
         @test length(vals_lanczos) == 1


### PR DESCRIPTION
### Summary

This PR extends the `eigsolve` function introduced in PR #157 by allowing the initial guess eigenvector `x₀` to be a `Tensor`. Previously, this variable had to be an `AbstractVector`. We also updated the tests to cover this extension.


### Example
```julia
julia> using KrylovKit

julia> using Tenet; using LinearAlgebra; using Test

julia> A = rand(ComplexF64, 4, 4)
4×4 Matrix{ComplexF64}: ...

julia> data = (A + A') / 2 # Make it Hermitian

julia> tensor = Tensor(data, (:i, :j))
4×4 Tensor{ComplexF64, 2, Matrix{ComplexF64}}: ..

julia> vals, vecs, info = eigsolve(tensor, Tensor(rand(ComplexF64, 4), (:i,)), 4, :SR, Lanczos(; krylovdim=4, tol=1e-16); left_inds=[:i], right_inds=[:j]) # Perform eigensolve
...

julia> V_matrix = hcat([reshape(parent(vec), :) for vec in vecs]...) # Convert vecs to matrix form for reconstruction
4×4 Matrix{ComplexF64}: ...

julia> D_matrix = Diagonal(vals)
4×4 Diagonal{Float64, Vector{Float64}}:
 -0.573245   ⋅          ⋅         ⋅ 
   ⋅        0.0709279   ⋅         ⋅ 
   ⋅         ⋅         0.430396   ⋅ 
   ⋅         ⋅          ⋅        2.32354

julia> reconstructed_matrix = V_matrix * D_matrix * inv(V_matrix)
4×4 Matrix{ComplexF64}: ...

julia> @test isapprox(reconstructed_matrix, parent(tensor))
Test Passed
```