### PR TITLE
Replace Gram-Schmidt method by QR for random Chain initialization

### DIFF
--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -254,8 +254,6 @@ function Base.rand(rng::Random.AbstractRNG, sampler::ChainSampler, ::Type{Open},
     F = lq!(rand(rng, T, min(χ, p), p))
     push!(arrays, Matrix(F.Q))
 
-    @show size.(arrays)
-
     return Chain(State(), Open(), arrays; order=(:l, :o, :r))
 end
 

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -240,7 +240,9 @@ function Base.rand(rng::Random.AbstractRNG, sampler::ChainSampler, ::Type{Open},
         χl = min(χ, p^(i - 1))
         χr = min(χ, p^i)
 
-        if i > n ÷ 2
+        if isodd(n) && i == n ÷ 2 + 1
+            χr = χl
+        elseif i > n ÷ 2
             j = (n + 1 - abs(2i - n - 1)) ÷ 2
             χl = min(χ, p^j)
             χr = min(χ, p^(j - 1))
@@ -277,7 +279,9 @@ function Base.rand(rng::Random.AbstractRNG, sampler::ChainSampler, ::Type{Open},
         χl = min(χ, ip^(i - 1) * op^(i - 1))
         χr = min(χ, ip^i * op^i)
 
-        if i > n ÷ 2
+        if isodd(n) && i == n ÷ 2 + 1
+            χr = χl
+        elseif i > n ÷ 2
             j = (n + 1 - abs(2i - n - 1)) ÷ 2
             χl = min(χ, ip^j * op^j)
             χr = min(χ, ip^(j - 1) * op^(j - 1))

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -238,7 +238,7 @@ function Base.rand(rng::Random.AbstractRNG, sampler::ChainSampler, ::Type{Open},
             (isodd(n) && i == n ÷ 2 + 1) ? (χl, χl) : (after_mid ? (χr, χl) : (χl, χr))
         end
 
-        # orthogonalize by Gram-Schmidt algorithm
+        # orthogonalize by QR factorization
         F = lq!(rand(rng, T, χl, p * χr))
 
         reshape(Matrix(F.Q), χl, p, χr)
@@ -269,7 +269,7 @@ function Base.rand(rng::Random.AbstractRNG, sampler::ChainSampler, ::Type{Open},
             (isodd(n) && i == n ÷ 2 + 1) ? (χl, χl) : (after_mid ? (χr, χl) : (χl, χr))
         end
 
-        # orthogonalize by Gram-Schmidt algorithm
+        # orthogonalize by QR factorization
         F = lq!(rand(rng, T, χl, ip * op * χr))
         reshape(Matrix(F.Q), χl, ip, op, χr)
     end
@@ -278,6 +278,7 @@ function Base.rand(rng::Random.AbstractRNG, sampler::ChainSampler, ::Type{Open},
     arrays[1] = reshape(arrays[1], p, p, min(χ, ip * op))
     arrays[n] = reshape(arrays[n], min(χ, ip * op), p, p)
 
+    # TODO order might not be the best for performance
     return Chain(Operator(), Open(), arrays; order=(:l, :i, :o, :r))
 end
 

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -236,7 +236,7 @@ function Base.rand(rng::Random.AbstractRNG, sampler::ChainSampler, ::Type{Open},
     push!(arrays, reshape(Matrix(F.Q), p, min(χ, p)))
 
     # Bulk tensors
-    for i in 2:n-1
+    for i in 2:(n - 1)
         χl = min(χ, p^(i - 1))
         χr = min(χ, p^i)
 
@@ -273,7 +273,7 @@ function Base.rand(rng::Random.AbstractRNG, sampler::ChainSampler, ::Type{Open},
     push!(arrays, reshape(Matrix(F.Q), ip, op, min(χ, ip * op)))
 
     # Bulk tensors
-    for i in 2:n-1
+    for i in 2:(n - 1)
         χl = min(χ, ip^(i - 1) * op^(i - 1))
         χr = min(χ, ip^i * op^i)
 
@@ -288,7 +288,7 @@ function Base.rand(rng::Random.AbstractRNG, sampler::ChainSampler, ::Type{Open},
     end
 
     # Right boundary tensor
-    F = lq!(rand(rng, T, min(χ, ip * op) , ip * op))
+    F = lq!(rand(rng, T, min(χ, ip * op), ip * op))
     push!(arrays, reshape(Matrix(F.Q), min(χ, ip * op), ip, op))
 
     return Chain(Operator(), Open(), arrays; order=(:l, :i, :o, :r))


### PR DESCRIPTION
In this PR, we replace the former Gram-Schmidt method for random chain initialization by a `QR` method, which applies the `qr` decomposition to some random tensors in order to get a randomly normalized right-canonized `MPS`.

Additionally, we benchmarked both methods and we conclude that the new method outscales the former in terms of running time, memory required and allocations produced.

### Comparison

· `Gram-Schmidt` method:
```julia
julia> using Tenet; using BenchmarkTools

julia> @btime mps = rand(Chain, Open, State; n=50, χ=300)
  2.002 s (53812 allocations: 122.75 MiB)
MPS (inputs=0, outputs=50)


julia> @btime mpo = rand(Chain, Open, Operator; n=50, χ=200)
  1.537 s (63338 allocations: 120.70 MiB)
MPO (inputs=50, outputs=50)
```

· `QR` method:
```julia
julia> using Tenet; using BenchmarkTools

julia> @btime mps = rand(Chain, Open, State; n=50, χ=300)
  423.495 ms (10480 allocations: 101.18 MiB)
MPS (inputs=0, outputs=50)

julia> @btime mpo = rand(Chain, Open, Operator; n=50, χ=200)
  573.715 ms (28459 allocations: 109.77 MiB)
MPO (inputs=50, outputs=50)
```