### PR TITLE
Fix reindex! by returing the final index replace mapping

### DIFF
--- a/src/Quantum.jl
+++ b/src/Quantum.jl
@@ -261,7 +261,8 @@ function reindex!(a::Quantum, ioa, b::Quantum, iob)
     _, mapping = replace!(TensorNetwork(b), replacements...)
 
     for site in sitesb
-        b.sites[site] = inds(b; at=site) ∈ keys(mapping) ? mapping[inds(b; at=site)] : inds(b; at=site)
+        ind = inds(b; at=ioa != iob ? site' : site)
+        b.sites[site] = ind ∈ keys(mapping) ? mapping[ind] : ind
     end
 
     return b

--- a/src/Quantum.jl
+++ b/src/Quantum.jl
@@ -261,7 +261,7 @@ function reindex!(a::Quantum, ioa, b::Quantum, iob)
     _, mapping = replace!(TensorNetwork(b), replacements...)
 
     for site in sitesb
-        ind = inds(b; at=ioa != iob ? site' : site)
+        ind = inds(a; at=ioa != iob ? site' : site)
         b.sites[site'] = b.sites[site] ∈ keys(mapping) ? mapping[b.sites[site]] : b.sites[site]
         b.sites[site] = ind ∈ keys(mapping) ? mapping[ind] : ind
     end

--- a/src/Quantum.jl
+++ b/src/Quantum.jl
@@ -258,10 +258,10 @@ function reindex!(a::Quantum, ioa, b::Quantum, iob)
 
     resetindex_mapping = resetindex!(Val(:return_mapping), TensorNetwork(b); init=ninds(TensorNetwork(a)))
     replacements = merge!(resetindex_mapping, Dict(replacements))
-    replace!(TensorNetwork(b), replacements...)
+    _, mapping = replace!(TensorNetwork(b), replacements...)
 
     for site in sitesb
-        b.sites[site] = inds(a; at=ioa != iob ? site' : site)
+        b.sites[site] = inds(b; at=site) ∈ keys(mapping) ? mapping[inds(b; at=site)] : inds(b; at=site)
     end
 
     return b

--- a/src/Quantum.jl
+++ b/src/Quantum.jl
@@ -262,6 +262,9 @@ end
 function reindex!(a::Quantum, ioa, b::Quantum, iob)
     ioa ∈ [:inputs, :outputs] || error("Invalid argument: :$ioa")
 
+    resetindex_mapping = resetindex!(Val(:return_mapping), TensorNetwork(b); init=ninds(TensorNetwork(a)))
+    resetindex!(a)
+
     sitesb = if iob === :inputs
         inputs(b)
     elseif iob === :outputs
@@ -283,6 +286,16 @@ function reindex!(a::Quantum, ioa, b::Quantum, iob)
     replace!(b, replacements)
 
     return b
+end
+
+function resetindex!(tn::Quantum; init=1)
+    mapping = resetindex!(Val(:return_mapping), TensorNetwork(tn); init)
+
+    replace!(TensorNetwork(tn), mapping)
+
+    for (site, index) in tn.sites
+        tn.sites[site] = mapping[index]
+    end
 end
 
 """

--- a/src/Quantum.jl
+++ b/src/Quantum.jl
@@ -262,8 +262,8 @@ end
 function reindex!(a::Quantum, ioa, b::Quantum, iob)
     ioa ∈ [:inputs, :outputs] || error("Invalid argument: :$ioa")
 
-    resetindex_mapping = resetindex!(Val(:return_mapping), TensorNetwork(b); init=ninds(TensorNetwork(a)))
     resetindex!(a)
+    resetindex!(b; init=ninds(TensorNetwork(a)) + 1)
 
     sitesb = if iob === :inputs
         inputs(b)
@@ -281,8 +281,6 @@ function reindex!(a::Quantum, ioa, b::Quantum, iob)
         return b
     end
 
-    resetindex_mapping = resetindex!(Val(:return_mapping), TensorNetwork(b); init=ninds(TensorNetwork(a)))
-    replacements = merge!(resetindex_mapping, Dict(replacements))
     replace!(b, replacements)
 
     return b
@@ -301,7 +299,7 @@ end
 """
     @reindex! a => b
 
-Reindexes the input/output sites of a [`Quantum`](@ref) Tensor Network `b` to match the input/output sites of another [`Quantum`](@ref) Tensor Network `a`.
+Reindexes the input/output sites of two [`Quantum`](@ref) Tensor Networks to be able to connect between them.
 """
 macro reindex!(expr)
     @assert Meta.isexpr(expr, :call) && expr.args[1] == :(=>)

--- a/src/Quantum.jl
+++ b/src/Quantum.jl
@@ -262,6 +262,7 @@ function reindex!(a::Quantum, ioa, b::Quantum, iob)
 
     for site in sitesb
         ind = inds(b; at=ioa != iob ? site' : site)
+        b.sites[site'] = b.sites[site] ∈ keys(mapping) ? mapping[b.sites[site]] : b.sites[site]
         b.sites[site] = ind ∈ keys(mapping) ? mapping[ind] : ind
     end
 

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -430,7 +430,8 @@ function Base.replace!(tn::TensorNetwork, old_new::Pair{Symbol,Symbol}...)
         replace!(tn, [tmp[i] => i for i in Iterators.filter(∈(overlap), to)]...)
     end
 
-    return tn
+    # return the final index mapping
+    return tn, Dict(from′ .=> to′)
 end
 
 function Base.replace!(tn::TensorNetwork, old_new::Pair{Symbol,Symbol})

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -420,24 +420,21 @@ function Base.replace!(tn::TensorNetwork, old_new::Base.AbstractVecOrTuple{Pair{
         ),
     )
 
-    from′ = setdiff(from, to)
-    to′ = setdiff(to, from)
-
-    # no overlap so easy replacement
-    for (f, t) in zip(from′, to′)
-        replace!(tn, f => t)
-    end
-
-    # overlap between old and new indices => need a temporary name `replace!`
     overlap = from ∩ to
-    if !isempty(overlap)
-        tmp = Dict([i => gensym(i) for i in overlap])
+    if isempty(overlap)
+        # no overlap so easy replacement
+        for (f, t) in zip(from, to)
+            replace!(tn, f => t)
+        end
+    else
+        # overlap between old and new indices => need a temporary name `replace!`
+        tmp = Dict([i => gensym(i) for i in from])
 
         # replace old indices with temporary names
-        replace!(tn, pairs(tmp)...)
+        replace!(tn, tmp)
 
         # replace temporary names with new indices
-        replace!(tn, [tmp[i] => i for i in Iterators.filter(∈(overlap), to)])
+        replace!(tn, [tmp[f] => t for (f, t) in zip(from, to)])
     end
 
     # return the final index mapping

--- a/test/Quantum_test.jl
+++ b/test/Quantum_test.jl
@@ -72,11 +72,11 @@
             @test issetequal([inds(mps; at=i) for i in outputs(mps)], [inds(mpo; at=i) for i in inputs(mpo)])
 
             # test that the both inputs/outputs appear on the corresponding tensor
-            @test all(Site(1:3)) do i
+            @test all(Site.(1:3)) do i
                 inds(mps; at=i) ∈ inds(tensors(mpo; at=i))
             end
 
-            @test all(Site(1:3)) do i
+            @test all(Site.(1:3)) do i
                 (inds(mpo; at=i), inds(mpo; at=i')) ⊆ inds(tensors(mpo; at=i))
             end
         end
@@ -109,11 +109,11 @@
             @test issetequal([inds(mps; at=i) for i in outputs(mps)], [inds(mpo; at=i) for i in inputs(mpo)])
 
             # test that the both inputs/outputs appear on the corresponding tensor
-            @test all(Site(1:3)) do i
+            @test all(Site.(1:3)) do i
                 inds(mps; at=i) ∈ inds(tensors(mpo; at=i))
             end
 
-            @test all(Site(1:3)) do i
+            @test all(Site.(1:3)) do i
                 (inds(mpo; at=i), inds(mpo; at=i')) ⊆ inds(tensors(mpo; at=i))
             end
         end

--- a/test/Quantum_test.jl
+++ b/test/Quantum_test.jl
@@ -45,47 +45,76 @@
 
     @testset "reindex!" begin
         @testset "manual indices" begin
-            _tensors = Tensor[Tensor(rand(2, 2), [:i, :j]), Tensor(rand(2, 2, 2), [:j, :k, :l]), Tensor(rand(2, 2), [:l, :m])]
-            tn = TensorNetwork(_tensors)
-            qtn = Quantum(tn, Dict(site"1" => :i, site"2" => :k, site"3" => :m)) # mps-like tensor network
+            # mps-like tensor network
+            mps = Quantum(
+                TensorNetwork(
+                    Tensor[
+                        Tensor(rand(2, 2), [:i, :j]), Tensor(rand(2, 2, 2), [:j, :k, :l]), Tensor(rand(2, 2), [:l, :m])
+                    ],
+                ),
+                Dict(site"1" => :i, site"2" => :k, site"3" => :m),
+            )
 
-            _tensors2 = Tensor[Tensor(rand(2, 2, 2), [:i, :j, :k]), Tensor(rand(2, 2, 2, 2), [:l, :m, :k, :n]), Tensor(rand(2, 2, 2), [:o, :p, :n])]
-            tn2 = TensorNetwork(_tensors2)
-            qtn2 = Quantum(tn2, Dict(site"1" => :i, site"1'" => :j, site"2" => :l, site"2'" => :m, site"3" => :o, site"3'" => :p)) # mpo-like tensor network
+            # mpo-like tensor network
+            mpo = Quantum(
+                TensorNetwork(
+                    Tensor[
+                        Tensor(rand(2, 2, 2), [:i, :j, :k]),
+                        Tensor(rand(2, 2, 2, 2), [:l, :m, :k, :n]),
+                        Tensor(rand(2, 2, 2), [:o, :p, :n]),
+                    ],
+                ),
+                Dict(site"1" => :i, site"1'" => :j, site"2" => :l, site"2'" => :m, site"3" => :o, site"3'" => :p),
+            )
 
-            Tenet.@reindex! outputs(qtn) => inputs(qtn2)
+            Tenet.@reindex! outputs(mps) => inputs(mpo)
 
-            @test issetequal([qtn.sites[i] for i in outputs(qtn)], [qtn2.sites[i] for i in inputs(qtn2)])
+            @test issetequal([inds(mps; at=i) for i in outputs(mps)], [inds(mpo; at=i) for i in inputs(mpo)])
 
             # test that the both inputs/outputs appear on the corresponding tensor
-            for i in 1:3
-                @test qtn.sites[outputs(qtn)[i]] in inds(tensors(qtn)[i])
-
-                @test qtn2.sites[inputs(qtn2)[i]] in inds(tensors(qtn2)[i])
-                @test qtn2.sites[outputs(qtn2)[i]] in inds(tensors(qtn2)[i])
+            @test all(Site(1:3)) do i
+                inds(mps; at=i) ∈ inds(tensors(mpo; at=i))
             end
 
+            @test all(Site(1:3)) do i
+                (inds(mpo; at=i), inds(mpo; at=i')) ⊆ inds(tensors(mpo; at=i))
+            end
         end
 
         @testset "regular indices" begin
-            _tensors = Tensor[Tensor(rand(2, 2), [:A, :B]), Tensor(rand(2, 2, 2), [:C, :B, :D]), Tensor(rand(2, 2), [:E, :D])]
-            tn = TensorNetwork(_tensors)
-            qtn = Quantum(tn, Dict(site"1" => :A, site"2" => :C, site"3" => :E)) # mps-like tensor network
+            # mps-like tensor network
+            mps = Quantum(
+                TensorNetwork(
+                    Tensor[
+                        Tensor(rand(2, 2), [:A, :B]), Tensor(rand(2, 2, 2), [:C, :B, :D]), Tensor(rand(2, 2), [:E, :D])
+                    ],
+                ),
+                Dict(site"1" => :A, site"2" => :C, site"3" => :E),
+            )
 
-            _tensors2 = Tensor[Tensor(rand(2, 2, 2), [:A, :B, :C]), Tensor(rand(2, 2, 2, 2), [:D, :E, :C, :F]), Tensor(rand(2, 2, 2), [:F, :G, :H])]
-            tn2 = TensorNetwork(_tensors2)
-            qtn2 = Quantum(tn2, Dict(site"1" => :A, site"1'" => :B, site"2" => :D, site"2'" => :E, site"3" => :G, site"3'" => :H)) # mpo-like tensor network
+            # mpo-like tensor network
+            mpo = Quantum(
+                TensorNetwork(
+                    Tensor[
+                        Tensor(rand(2, 2, 2), [:A, :B, :C]),
+                        Tensor(rand(2, 2, 2, 2), [:D, :E, :C, :F]),
+                        Tensor(rand(2, 2, 2), [:F, :G, :H]),
+                    ],
+                ),
+                Dict(site"1" => :A, site"1'" => :B, site"2" => :D, site"2'" => :E, site"3" => :G, site"3'" => :H),
+            )
 
-            Tenet.@reindex! outputs(qtn) => inputs(qtn2)
+            Tenet.@reindex! outputs(mps) => inputs(mpo)
 
-            @test issetequal([qtn.sites[i] for i in outputs(qtn)], [qtn2.sites[i] for i in inputs(qtn2)])
+            @test issetequal([inds(mps; at=i) for i in outputs(mps)], [inds(mpo; at=i) for i in inputs(mpo)])
 
             # test that the both inputs/outputs appear on the corresponding tensor
-            for i in 1:3
-                @test qtn.sites[outputs(qtn)[i]] in inds(tensors(qtn)[i])
+            @test all(Site(1:3)) do i
+                inds(mps; at=i) ∈ inds(tensors(mpo; at=i))
+            end
 
-                @test qtn2.sites[inputs(qtn2)[i]] in inds(tensors(qtn2)[i])
-                @test qtn2.sites[outputs(qtn2)[i]] in inds(tensors(qtn2)[i])
+            @test all(Site(1:3)) do i
+                (inds(mpo; at=i), inds(mpo; at=i')) ⊆ inds(tensors(mpo; at=i))
             end
         end
     end

--- a/test/Quantum_test.jl
+++ b/test/Quantum_test.jl
@@ -53,9 +53,6 @@
             tn2 = TensorNetwork(_tensors2)
             qtn2 = Quantum(tn2, Dict(site"1" => :i, site"1'" => :j, site"2" => :l, site"2'" => :m, site"3" => :o, site"3'" => :p)) # mpo-like tensor network
 
-            T₁ = tensors(qtn; at=site"1")
-            U₁ = tensors(qtn2; at=site"1")
-
             Tenet.@reindex! outputs(qtn) => inputs(qtn2)
 
             @test issetequal([qtn2.sites[i] for i in inputs(qtn2)], [qtn.sites[i] for i in outputs(qtn)])
@@ -69,9 +66,6 @@
             _tensors2 = Tensor[Tensor(rand(2, 2, 2), [:A, :B, :C]), Tensor(rand(2, 2, 2, 2), [:D, :E, :C, :F]), Tensor(rand(2, 2, 2), [:F, :G, :H])]
             tn2 = TensorNetwork(_tensors2)
             qtn2 = Quantum(tn2, Dict(site"1" => :A, site"1'" => :B, site"2" => :D, site"2'" => :E, site"3" => :G, site"3'" => :H)) # mpo-like tensor network
-
-            T₁ = tensors(qtn; at=site"1")
-            U₁ = tensors(qtn2; at=site"1")
 
             Tenet.@reindex! outputs(qtn) => inputs(qtn2)
 

--- a/test/Quantum_test.jl
+++ b/test/Quantum_test.jl
@@ -55,7 +55,16 @@
 
             Tenet.@reindex! outputs(qtn) => inputs(qtn2)
 
-            @test issetequal([qtn2.sites[i] for i in inputs(qtn2)], [qtn.sites[i] for i in outputs(qtn)])
+            @test issetequal([qtn.sites[i] for i in outputs(qtn)], [qtn2.sites[i] for i in inputs(qtn2)])
+
+            # test that the both inputs/outputs appear on the corresponding tensor
+            for i in 1:3
+                @test qtn.sites[outputs(qtn)[i]] in inds(tensors(qtn)[i])
+
+                @test qtn2.sites[inputs(qtn2)[i]] in inds(tensors(qtn2)[i])
+                @test qtn2.sites[outputs(qtn2)[i]] in inds(tensors(qtn2)[i])
+            end
+
         end
 
         @testset "regular indices" begin
@@ -69,7 +78,15 @@
 
             Tenet.@reindex! outputs(qtn) => inputs(qtn2)
 
-            @test issetequal([qtn2.sites[i] for i in inputs(qtn2)], [qtn.sites[i] for i in outputs(qtn)])
+            @test issetequal([qtn.sites[i] for i in outputs(qtn)], [qtn2.sites[i] for i in inputs(qtn2)])
+
+            # test that the both inputs/outputs appear on the corresponding tensor
+            for i in 1:3
+                @test qtn.sites[outputs(qtn)[i]] in inds(tensors(qtn)[i])
+
+                @test qtn2.sites[inputs(qtn2)[i]] in inds(tensors(qtn2)[i])
+                @test qtn2.sites[outputs(qtn2)[i]] in inds(tensors(qtn2)[i])
+            end
         end
     end
 end

--- a/test/Quantum_test.jl
+++ b/test/Quantum_test.jl
@@ -42,4 +42,40 @@
     tn = TensorNetwork(_tensors)
     @test_throws ErrorException Quantum(tn, Dict(site"1" => :j))
     @test_throws ErrorException Quantum(tn, Dict(site"1" => :i))
+
+    @testset "reindex!" begin
+        @testset "manual indices" begin
+            _tensors = Tensor[Tensor(rand(2, 2), [:i, :j]), Tensor(rand(2, 2, 2), [:j, :k, :l]), Tensor(rand(2, 2), [:l, :m])]
+            tn = TensorNetwork(_tensors)
+            qtn = Quantum(tn, Dict(site"1" => :i, site"2" => :k, site"3" => :m)) # mps-like tensor network
+
+            _tensors2 = Tensor[Tensor(rand(2, 2, 2), [:i, :j, :k]), Tensor(rand(2, 2, 2, 2), [:l, :m, :k, :n]), Tensor(rand(2, 2, 2), [:o, :p, :n])]
+            tn2 = TensorNetwork(_tensors2)
+            qtn2 = Quantum(tn2, Dict(site"1" => :i, site"1'" => :j, site"2" => :l, site"2'" => :m, site"3" => :o, site"3'" => :p)) # mpo-like tensor network
+
+            T₁ = tensors(qtn; at=site"1")
+            U₁ = tensors(qtn2; at=site"1")
+
+            Tenet.@reindex! outputs(qtn) => inputs(qtn2)
+
+            @test issetequal([qtn2.sites[i] for i in inputs(qtn2)], [qtn.sites[i] for i in outputs(qtn)])
+        end
+
+        @testset "regular indices" begin
+            _tensors = Tensor[Tensor(rand(2, 2), [:A, :B]), Tensor(rand(2, 2, 2), [:C, :B, :D]), Tensor(rand(2, 2), [:E, :D])]
+            tn = TensorNetwork(_tensors)
+            qtn = Quantum(tn, Dict(site"1" => :A, site"2" => :C, site"3" => :E)) # mps-like tensor network
+
+            _tensors2 = Tensor[Tensor(rand(2, 2, 2), [:A, :B, :C]), Tensor(rand(2, 2, 2, 2), [:D, :E, :C, :F]), Tensor(rand(2, 2, 2), [:F, :G, :H])]
+            tn2 = TensorNetwork(_tensors2)
+            qtn2 = Quantum(tn2, Dict(site"1" => :A, site"1'" => :B, site"2" => :D, site"2'" => :E, site"3" => :G, site"3'" => :H)) # mpo-like tensor network
+
+            T₁ = tensors(qtn; at=site"1")
+            U₁ = tensors(qtn2; at=site"1")
+
+            Tenet.@reindex! outputs(qtn) => inputs(qtn2)
+
+            @test issetequal([qtn2.sites[i] for i in inputs(qtn2)], [qtn.sites[i] for i in outputs(qtn)])
+        end
+    end
 end

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -303,7 +303,7 @@
         @test t_ilm === tn[:i, :l, :m]
         @test t_lm === tn[:l, :m]
 
-        # NOTE although it should throw `KeyError`, it throws `ArgumentError` due to implementation 
+        # NOTE although it should throw `KeyError`, it throws `ArgumentError` due to implementation
         @test_throws ArgumentError tn[:i, :x]
         @test_throws ArgumentError tn[:i, :j, :k]
     end
@@ -526,6 +526,27 @@
             @test issetequal(finalinds, inds(tnA))
             @test issetequal(finaltensors, tensors(tnA))
         end
+    end
+
+    @testset "complicated replacement" begin
+        A = Tensor(rand(2, 2, 2), (:F, :A, :K))
+        B = Tensor(rand(2, 2, 2, 2), (:K, :G, :B, :L))
+        C = Tensor(rand(2, 2, 2, 2), (:L, :H, :C, :M))
+        D = Tensor(rand(2, 2, 2, 2), (:M, :I, :D, :N))
+        E = Tensor(rand(2, 2, 2), (:N, :J, :E))
+
+        old_new = [:N => :N, :F => :A, :M => :O, :A => :P, :D => :J, :B => :K, :I => :D, :H => :C, :G => :B, :J => :E, :K => :L, :L => :U, :E => :M, :C => :V]
+        tn = TensorNetwork([A, B, C, D, E])
+
+        replace!(tn, old_new...)
+
+        # issetequal to this
+        # [:O, :A, :K]
+        # [:K, :V, :B, :L]
+        # [:L, :U, :C, :M]
+        # [:M, :P, :D, :N]
+        # [:N, :J, :E]
+        @test issetequal(vcat(collect(values(tn.tensormap))...), vcat([[:O, :A, :K], [:K, :V, :B, :L], [:L, :U, :C, :M], [:M, :P, :D, :N], [:N, :J, :E]]...))
     end
 
     @testset "Base.in" begin

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -528,14 +528,29 @@
         end
     end
 
-    @testset "complicated replacement" begin
+    @testset "overlapping replacement" begin
         A = Tensor(rand(2, 2, 2), (:F, :A, :K))
         B = Tensor(rand(2, 2, 2, 2), (:K, :G, :B, :L))
         C = Tensor(rand(2, 2, 2, 2), (:L, :H, :C, :M))
         D = Tensor(rand(2, 2, 2, 2), (:M, :I, :D, :N))
         E = Tensor(rand(2, 2, 2), (:N, :J, :E))
 
-        old_new = [:N => :N, :F => :A, :M => :O, :A => :P, :D => :J, :B => :K, :I => :D, :H => :C, :G => :B, :J => :E, :K => :L, :L => :U, :E => :M, :C => :V]
+        old_new = [
+            :N => :N,
+            :F => :A,
+            :M => :O,
+            :A => :P,
+            :D => :J,
+            :B => :K,
+            :I => :D,
+            :H => :C,
+            :G => :B,
+            :J => :E,
+            :K => :L,
+            :L => :U,
+            :E => :M,
+            :C => :V,
+        ]
         tn = TensorNetwork([A, B, C, D, E])
 
         replace!(tn, old_new...)
@@ -546,7 +561,9 @@
         # [:L, :U, :C, :M]
         # [:M, :P, :D, :N]
         # [:N, :J, :E]
-        @test issetequal(vcat(collect(values(tn.tensormap))...), vcat([[:O, :A, :K], [:K, :V, :B, :L], [:L, :U, :C, :M], [:M, :P, :D, :N], [:N, :J, :E]]...))
+        @test issetequal(
+            inds.(tensors(tn)), [[:O, :A, :K], [:K, :V, :B, :L], [:L, :U, :C, :M], [:M, :P, :D, :N], [:N, :J, :E]]
+        )
     end
 
     @testset "Base.in" begin

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -526,44 +526,44 @@
             @test issetequal(finalinds, inds(tnA))
             @test issetequal(finaltensors, tensors(tnA))
         end
-    end
 
-    @testset "overlapping replacement" begin
-        A = Tensor(rand(2, 2, 2), (:F, :A, :K))
-        B = Tensor(rand(2, 2, 2, 2), (:K, :G, :B, :L))
-        C = Tensor(rand(2, 2, 2, 2), (:L, :H, :C, :M))
-        D = Tensor(rand(2, 2, 2, 2), (:M, :I, :D, :N))
-        E = Tensor(rand(2, 2, 2), (:N, :J, :E))
+        @testset "overlapping replacement" begin
+            A = Tensor(rand(2, 2, 2), (:F, :A, :K))
+            B = Tensor(rand(2, 2, 2, 2), (:K, :G, :B, :L))
+            C = Tensor(rand(2, 2, 2, 2), (:L, :H, :C, :M))
+            D = Tensor(rand(2, 2, 2, 2), (:M, :I, :D, :N))
+            E = Tensor(rand(2, 2, 2), (:N, :J, :E))
 
-        old_new = [
-            :N => :N,
-            :F => :A,
-            :M => :O,
-            :A => :P,
-            :D => :J,
-            :B => :K,
-            :I => :D,
-            :H => :C,
-            :G => :B,
-            :J => :E,
-            :K => :L,
-            :L => :U,
-            :E => :M,
-            :C => :V,
-        ]
-        tn = TensorNetwork([A, B, C, D, E])
+            old_new = [
+                :N => :N,
+                :F => :A,
+                :M => :O,
+                :A => :P,
+                :D => :J,
+                :B => :K,
+                :I => :D,
+                :H => :C,
+                :G => :B,
+                :J => :E,
+                :K => :L,
+                :L => :U,
+                :E => :M,
+                :C => :V,
+            ]
+            tn = TensorNetwork([A, B, C, D, E])
 
-        replace!(tn, old_new...)
+            replace!(tn, old_new...)
 
-        # issetequal to this
-        # [:O, :A, :K]
-        # [:K, :V, :B, :L]
-        # [:L, :U, :C, :M]
-        # [:M, :P, :D, :N]
-        # [:N, :J, :E]
-        @test issetequal(
-            inds.(tensors(tn)), [[:O, :A, :K], [:K, :V, :B, :L], [:L, :U, :C, :M], [:M, :P, :D, :N], [:N, :J, :E]]
-        )
+            # issetequal to this
+            # [:O, :A, :K]
+            # [:K, :V, :B, :L]
+            # [:L, :U, :C, :M]
+            # [:M, :P, :D, :N]
+            # [:N, :J, :E]
+            @test issetequal(
+                inds.(tensors(tn)), [[:O, :A, :K], [:K, :V, :B, :L], [:L, :U, :C, :M], [:M, :P, :D, :N], [:N, :J, :E]]
+            )
+        end
     end
 
     @testset "Base.in" begin

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -554,14 +554,8 @@
 
             replace!(tn, old_new...)
 
-            # issetequal to this
-            # [:O, :A, :K]
-            # [:K, :V, :B, :L]
-            # [:L, :U, :C, :M]
-            # [:M, :P, :D, :N]
-            # [:N, :J, :E]
             @test issetequal(
-                inds.(tensors(tn)), [[:O, :A, :K], [:K, :V, :B, :L], [:L, :U, :C, :M], [:M, :P, :D, :N], [:N, :J, :E]]
+                inds.(tensors(tn)), [[:A, :P, :L], [:L, :B, :K, :U], [:U, :C, :V, :O], [:O, :D, :J, :N], [:N, :E, :M]]
             )
         end
     end


### PR DESCRIPTION
### Summary
This PR resolves #177 by correctly fixing the reindex of the `site` indices. To do that, we modified the `replace!` function by returning the final index mapping. I believe this is the most efficient way to do this since we could also get the mapping by comparing the tensor before and after the `replace!`, but this seems to do unnecessary work.

### Example
Now the following code works fine:
```julia
julia> mps = rand(Chain, Open, State; n=5, p=2, χ=20)
MPS (inputs=0, outputs=5)

julia> mpo = rand(Chain, Open, Operator; n=5, χ=2, p=2)
MPO (inputs=5, outputs=5)

julia> inds(mpo, at = Site(1))
:A

julia> inds(mpo, at = Site(1; dual=true))
:F

julia> Tenet.@reindex! outputs(mps) => inputs(mpo)
MPO (inputs=5, outputs=5)

julia> inds(mpo, at = Site(1))
:A

julia> inds(mpo, at = Site(1; dual=true))
:O

julia> inds.(mpo)
5-element Vector{Vector{Symbol}}:
 [:K, :V, :B, :L]
 [:L, :U, :C, :M]
 [:M, :P, :D, :N]
 [:N, :J, :E]
 [:O, :A, :K]
 
julia> contract(merge(TensorNetwork(mps), TensorNetwork(mpo))) # We get a 5-dimensional tensor as expected
2×2×2×2×2 Tensor{Float64, 5, Array{Float64, 5}}: ...
```