### PR TITLE
Implement `inds` method for physical and virtual indices

### DIFF
--- a/src/Quantum.jl
+++ b/src/Quantum.jl
@@ -1,3 +1,5 @@
+using KeywordDispatch
+
 """
     AbstractQuantum
 
@@ -174,6 +176,15 @@ function Base.show(io::IO, q::Quantum)
 end
 
 @kwmethod inds(tn::AbstractQuantum; at) = Quantum(tn).sites[at]
+@kwmethod function inds(tn::AbstractQuantum; set)
+    if set === :physical
+        return values(Quantum(tn).sites)
+    elseif set === :virtual
+        return setdiff(inds(tn), values(Quantum(tn).sites))
+    else
+        return inds(TensorNetwork(tn); set)
+    end
+end
 
 """
     adjoint(q::Quantum)

--- a/test/Quantum_test.jl
+++ b/test/Quantum_test.jl
@@ -8,6 +8,9 @@
     @test nsites(qtn; set=:outputs) == 1
     @test issetequal(sites(qtn), [site"1"])
     @test socket(qtn) == State(; dual=false)
+    @test inds(qtn; at=site"1") == :i
+    @test issetequal(inds(qtn; set=:physical), [:i])
+    @test isempty(inds(qtn; set=:virtual))
 
     # forwarded methods to `TensorNetwork`
     @test TensorNetwork(qtn) == tn
@@ -20,6 +23,9 @@
     @test nsites(qtn; set=:outputs) == 0
     @test issetequal(sites(qtn), [site"1'"])
     @test socket(qtn) == State(; dual=true)
+    @test inds(qtn; at=site"1'") == :i
+    @test issetequal(inds(qtn; set=:physical), [:i])
+    @test isempty(inds(qtn; set=:virtual))
 
     _tensors = Tensor[Tensor(zeros(2, 2), [:i, :j])]
     tn = TensorNetwork(_tensors)
@@ -28,6 +34,10 @@
     @test nsites(qtn; set=:outputs) == 1
     @test issetequal(sites(qtn), [site"1", site"1'"])
     @test socket(qtn) == Operator()
+    @test inds(qtn; at=site"1") == :i
+    @test inds(qtn; at=site"1'") == :j
+    @test issetequal(inds(qtn; set=:physical), [:i, :j])
+    @test isempty(inds(qtn; set=:virtual))
 
     _tensors = Tensor[Tensor(fill(0))]
     tn = TensorNetwork(_tensors)
@@ -36,6 +46,8 @@
     @test nsites(qtn; set=:outputs) == 0
     @test isempty(sites(qtn))
     @test socket(qtn) == Scalar()
+    @test isempty(inds(qtn; set=:physical))
+    @test isempty(inds(qtn; set=:virtual))
 
     # detect errors
     _tensors = Tensor[Tensor(zeros(2), [:i]), Tensor(zeros(2), [:i])]


### PR DESCRIPTION
With this PR, `inds(tn; set=:physical)` would return the physical indices annotated in the `sites` dict of `Quantum`, and `inds(tn; set=:virtual)` would return the virtual indices (i.e. the set difference between all the indices and the physical indices).