### PR TITLE
fix error message for wrong set in inds()

### DIFF
--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -400,7 +400,11 @@ end
     elseif set === :hyper
         map(first, Iterators.filter(((_, v),) -> length(v) >= 3, tn.indexmap))
     else
-        throw(MethodError(inds, "unknown query: $set"))
+      throw(ArgumentError("unknown query: set=$(set). 
+        Possible options are: 
+        :all, :open :inner :hyper :parallelto
+        For Quantum also :physical :virtual
+        "))
     end
 end
 

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -400,11 +400,17 @@ end
     elseif set === :hyper
         map(first, Iterators.filter(((_, v),) -> length(v) >= 3, tn.indexmap))
     else
-      throw(ArgumentError("unknown query: set=$(set). 
-        Possible options are: 
-        :all, :open :inner :hyper :parallelto
-        For Quantum also :physical :virtual
-        "))
+      throw(ArgumentError("""
+        Unknown query: set=$(set) 
+        Possible options are:
+          - :all (default)
+          - :open
+          - :inner
+          - :hyper
+        For `AbstractQuantum`, the following are also available:
+          - :physical
+          - :virtual
+        """))
     end
 end
 


### PR DESCRIPTION
if you call inds(::Chain) with the wrong  set = option, Tenet throws an obscure error - I don't know if this is due to a wrong use of MethodError, I changed it for an ArgumentError and it works. I also added some extra info, so now it throws

```
julia> inds(psi, set=:sergio)
ERROR: ArgumentError: unknown query: set=sergio.
        Possible options are:
        :all, :open :inner :hyper :parallelto
        For Quantum also :physical :virtual
```
