### PR TITLE
Fix mutation on `conj`, `adjoint`

### DIFF
--- a/src/Quantum.jl
+++ b/src/Quantum.jl
@@ -191,7 +191,7 @@ end
 
 Returns the adjoint of a [`Quantum`](@ref) Tensor Network; i.e. the conjugate Tensor Network with the inputs and outputs swapped.
 """
-Base.adjoint(tn::AbstractQuantum) = adjoint!(copy(tn))
+Base.adjoint(tn::AbstractQuantum) = adjoint!(deepcopy(tn))
 
 function LinearAlgebra.adjoint!(tn::AbstractQuantum)
     conj!(tn)

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -80,7 +80,7 @@ Base.size(tn::AbstractTensorNetwork, args...) = size(TensorNetwork(tn), args...)
 
 Base.eltype(tn::AbstractTensorNetwork) = promote_type(eltype.(tensors(tn))...)
 
-Base.conj(tn::AbstractTensorNetwork) = conj!(copy(tn))
+Base.conj(tn::AbstractTensorNetwork) = conj!(deepcopy(tn))
 function Base.conj!(tn::AbstractTensorNetwork)
     foreach(conj!, tensors(tn))
     return tn


### PR DESCRIPTION
`conj` (and thus `adjoint` because it calls `conj`) was mutating the arrays of the original `TensorNetwork` when it shouldn't.

The reason is that we were doing a _shallow_ copy (i.e. `copy`) instead of a _deep_ copy (i.e. `deepcopy`).