### PR TITLE
Fix error throw in `replace!`

### DIFF
--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -225,6 +225,7 @@ function Base.replace!(tn::AbstractTensorNetwork, pair::Pair{<:Tensor,<:Tensor})
     old_tensor, new_tensor = pair
     issetequal(inds(new_tensor), inds(old_tensor)) || throw(ArgumentError("replacing tensor indices don't match"))
 
+    push!(tn, new_tensor)
     delete!(tn, old_tensor)
     push!(tn, new_tensor)
 

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -227,7 +227,6 @@ function Base.replace!(tn::AbstractTensorNetwork, pair::Pair{<:Tensor,<:Tensor})
 
     push!(tn, new_tensor)
     delete!(tn, old_tensor)
-    push!(tn, new_tensor)
 
     return tn
 end


### PR DESCRIPTION
This PR resolves #191, so now if we use `replace!` and it throws an error, we do not get any destructive problems.

#### Example
```julia
julia> using Tenet

julia> psi = rand(Chain, Open, State; n=5, χ=8)
MPS (inputs=0, outputs=5)

julia> i2 = inds(tensors(psi, at=Site(2)))
3-element Vector{Symbol}: ...

julia> t2n_alt = Tensor(rand(2,2,10), i2)
2×2×10 Tensor{Float64, 3, Array{Float64, 3}}: ...

julia> size.(tensors(psi))
5-element Vector{Tuple{Int64, Int64, Vararg{Int64}}}:
 (2, 2)
 (2, 2, 4)
 (4, 2, 4)
 (4, 2, 2)
 (2, 2)

julia> replace!(psi, tensors(psi,at=Site(2)) => t2n_alt)
ERROR: DimensionMismatch: size(tensor,G)=10 but should be equal to size(tn,G)=4
Stacktrace:
 [1] push!(tn::TensorNetwork, tensor::Tensor{Float64, 3, Array{Float64, 3}})
   @ Tenet ~/git/Tenet.jl/src/TensorNetwork.jl:538
 [2] replace!(tn::Chain, pair::Pair{Tensor{Float64, 3, Array{Float64, 3}}, Tensor{Float64, 3, Array{Float64, 3}}})
   @ Tenet ~/git/Tenet.jl/src/TensorNetwork.jl:228
 [3] top-level scope
   @ REPL[6]:1

julia> size.(tensors(psi))
5-element Vector{Tuple{Int64, Int64, Vararg{Int64}}}:
 (2, 2)
 (2, 2, 4)
 (4, 2, 4)
 (4, 2, 2)
 (2, 2)
```