### PR TITLE
Fix `Yao` extension by properly transposing matrices

### DIFF
--- a/ext/TenetYaoBlocksExt.jl
+++ b/ext/TenetYaoBlocksExt.jl
@@ -31,7 +31,7 @@ function Tenet.Quantum(circuit::AbstractBlock)
         else
             content(gate)
         end
-        array = reshape(mat(operator), fill(nlevel(operator), 2 * nqubits(operator))...)
+        array = reshape(transpose(mat(operator)), fill(nlevel(operator), 2 * nqubits(operator))...)
 
         inds = (x -> collect(Iterators.flatten(zip(x...))))(
             map(occupied_locs(gate)) do l

--- a/ext/TenetYaoBlocksExt.jl
+++ b/ext/TenetYaoBlocksExt.jl
@@ -31,13 +31,13 @@ function Tenet.Quantum(circuit::AbstractBlock)
         else
             content(gate)
         end
-        array = reshape(transpose(mat(operator)), fill(nlevel(operator), 2 * nqubits(operator))...)
+        array = reshape(mat(operator), fill(nlevel(operator), 2 * nqubits(operator))...)
 
         inds = (x -> collect(Iterators.flatten(zip(x...))))(
             map(occupied_locs(gate)) do l
                 from, to = last(wire[l]), Tenet.nextindex!(gen)
                 push!(wire[l], to)
-                (from, to)
+                (to, from)
             end,
         )
 

--- a/test/integration/YaoBlocks_test.jl
+++ b/test/integration/YaoBlocks_test.jl
@@ -25,7 +25,7 @@
 
     @testset "two-qubit gate" begin
         U = matblock(rand(ComplexF64, 4, 4); tag="U")
-        circuit = chain(2, put((1, 2)=>U))
+        circuit = chain(2, put((1, 2) => U))
         psi = zero_state(2)
         apply!(psi, circuit)
 

--- a/test/integration/YaoBlocks_test.jl
+++ b/test/integration/YaoBlocks_test.jl
@@ -9,12 +9,7 @@
     @test Tenet.ntensors(tn) == 2
 
     @testset "GHZ Circuit" begin
-        circuit_GHZ = chain(
-            n_qubits,
-            put(1=>Yao.H),
-            Yao.control(1, 2=>Yao.X),
-            Yao.control(2, 3=>Yao.X)
-        )
+        circuit_GHZ = chain(n_qubits, put(1 => Yao.H), Yao.control(1, 2 => Yao.X), Yao.control(2, 3 => Yao.X))
 
         quantum_circuit = Quantum(circuit_GHZ)
 
@@ -22,9 +17,9 @@
         ones = Quantum(Product(fill([0, 1], n_qubits))) #|111>
 
         expected_value = Tenet.contract(merge(zeros, quantum_circuit, ones')) # <111|circuit|000>
-        @test only(expected_value) ≈ 1/√2
+        @test only(expected_value) ≈ 1 / √2
 
         SV_Yao = apply!(zero_state(n_qubits), circuit_GHZ) # circuit|000>
-        @test only(statevec(ArrayReg(bit"111"))' * statevec(SV_Yao)) ≈ 1/√2
+        @test only(statevec(ArrayReg(bit"111"))' * statevec(SV_Yao)) ≈ 1 / √2
     end
 end

--- a/test/integration/YaoBlocks_test.jl
+++ b/test/integration/YaoBlocks_test.jl
@@ -22,4 +22,21 @@
         SV_Yao = apply!(zero_state(n_qubits), circuit_GHZ) # circuit|000>
         @test only(statevec(ArrayReg(bit"111"))' * statevec(SV_Yao)) ≈ 1 / √2
     end
+
+    @testset "two-qubit gate" begin
+        U = matblock(rand(ComplexF64, 4, 4); tag="U")
+        circuit = chain(2, put((1, 2)=>U))
+        psi = zero_state(2)
+        apply!(psi, circuit)
+
+        quantum_circuit = Quantum(circuit)
+        zeros = Quantum(Product(fill([1, 0], 2))) #|00>
+        ones = Quantum(Product(fill([0, 1], 2))) #|11>
+
+        expected_value = Tenet.contract(merge(zeros, quantum_circuit, ones')) # <11|circuit|00>
+
+        SV_Yao = apply!(zero_state(2), circuit) # circuit|00>
+
+        @test only(expected_value) ≈ only(statevec(ArrayReg(bit"11"))' * statevec(SV_Yao))
+    end
 end

--- a/test/integration/YaoBlocks_test.jl
+++ b/test/integration/YaoBlocks_test.jl
@@ -7,4 +7,24 @@
 
     @test issetequal(sites(tn), [site"1", site"2", site"1'", site"2'"])
     @test Tenet.ntensors(tn) == 2
+
+    @testset "GHZ Circuit" begin
+        circuit_GHZ = chain(
+            n_qubits,
+            put(1=>Yao.H),
+            Yao.control(1, 2=>Yao.X),
+            Yao.control(2, 3=>Yao.X)
+        )
+
+        quantum_circuit = Quantum(circuit_GHZ)
+
+        zeros = Quantum(Product(fill([1, 0], n_qubits))) #|000>
+        ones = Quantum(Product(fill([0, 1], n_qubits))) #|111>
+
+        expected_value = Tenet.contract(merge(zeros, quantum_circuit, ones')) # <111|circuit|000>
+        @test only(expected_value) ≈ 1/√2
+
+        SV_Yao = apply!(zero_state(n_qubits), circuit_GHZ) # circuit|000>
+        @test only(statevec(ArrayReg(bit"111"))' * statevec(SV_Yao)) ≈ 1/√2
+    end
 end


### PR DESCRIPTION
This PR resolves #210 by transposing the matrices received from `Yao`. This has to be done, since `Yao`'s conventions seem to be (outputs, inputs), rather than (inputs, outputs)  that we usually do. See that this problem is now fixed:

```julia
julia> using Yao; using Tenet

julia> phase = 2*acos(1/sqrt(3))
1.9106332362490184

julia> circuit = chain(n_qubits, put(1=>Yao.Ry(phase)), Yao.control(1, 2=>Yao.H), Yao.control(2, 3=>Yao.X), Yao.control(1, 2=>Yao.X), put(1=>Yao.X))
nqubits: 3
chain
├─ put on (1)
│  └─ rot(Y, 1.9106332362490184)
├─ control(1)
│  └─ (2,) H
├─ control(2)
│  └─ (3,) X
├─ control(1)
│  └─ (2,) X
└─ put on (1)
   └─ X

julia> SV_Yao = apply!(zero_state(n_qubits), circuit) # circuit|000> 
ArrayReg{2, ComplexF64, Array...}
    active qubits: 3/3
    nlevel: 2

julia> statevec(SV_Yao)
8-element Vector{ComplexF64}:
               -0.0 + 0.0im
 0.5773502691896258 + 0.0im
 0.5773502691896257 + 0.0im
                0.0 + 0.0im
 0.5773502691896257 + 0.0im
                0.0 + 0.0im
                0.0 + 0.0im
                0.0 + 0.0im

julia> psi000 = Tenet.Quantum(Tenet.Product(fill([1, 0], n_qubits))) #|000>
Quantum (inputs=0, outputs=3)

julia> merged_circ = merge(psi000, Tenet.Quantum(circuit)) # circuit|000> 
Quantum (inputs=0, outputs=3)

julia> inds_order = find_permutation(merged_circ)
(:G, :K, :M)

julia> SV_Tenet = reshape(permutedims(Tenet.contract(merged_circ), inds_order), 2^n_qubits)
8-element reshape(::Tensor{ComplexF64, 3, Array{ComplexF64, 3}}, 8) with eltype ComplexF64:
                0.0 + 0.0im
 0.5773502691896258 + 0.0im
 0.5773502691896257 + 0.0im
                0.0 + 0.0im
 0.5773502691896257 + 0.0im
                0.0 + 0.0im
                0.0 + 0.0im
                0.0 + 0.0im

julia> psi_100 = Tenet.Quantum(Tenet.Product([[0, 1], [1, 0], [1, 0]]))
Quantum (inputs=0, outputs=3)

julia> Tenet.contract(merge(psi000, quantum_circuit, psi_100'))
0-dimensional Tensor{ComplexF64, 0, Array{ComplexF64, 0}}:
0.5773502691896258 + 0.0im

julia> statevec(ArrayReg(bit"100"))' * statevec(SV_Yao)
0.5773502691896257 + 0.0im
```
@amrFRE, see that here I computed some expectation values too.
 
Note that I used the function `find_permutation` to permute the result tensor so it follows the usual order (site1, site2, site3). @mofeing, shouldn't we add this function too? I think it makes sense, since if we want the state vector we should permute the tensor properly before the reshape.

This is the function I used:
```julia

"""
    find_permutation(qtn::Quantum, n_qubits::Int)

Generates a permutation tuple that orders the sites such that all dual (input) sites
are first in ascending qubit order, followed by all regular sites in ascending qubit order.

# Arguments
- `qtn`: A Quantum Tensor Network

# Returns
- A tuple representing the desired permutation of symbols.

"""
function find_permutation(qtn::Quantum)
    sites = qtn.sites # Dict{Site, Symbol}

    # Initialize arrays to hold dual and regular sites
    dual_sites = Vector{Tuple{Int, Symbol}}()
    regular_sites = Vector{Tuple{Int, Symbol}}()

    # Iterate over each site in the dictionary
    for (site_key, sym) in sites
        if Tenet.isdual(site_key)
            qubit = Tenet.id(site_key)

            # Append to dual_sites
            push!(dual_sites, (qubit, sym))
        else
            # Regular site: extract qubit index
            qubit = Tenet.id(site_key)

            # Append to regular_sites
            push!(regular_sites, (qubit, sym))
        end
    end

    # Sort dual_sites by qubit index in ascending order
    sort!(dual_sites, by = x -> x[1])

    # Sort regular_sites by qubit index in ascending order
    sort!(regular_sites, by = x -> x[1])

    # Extract the symbols in the sorted order
    dual_order = [x[2] for x in dual_sites]
    regular_order = [x[2] for x in regular_sites]

    # Combine dual and regular orders into a single tuple based on availability
    if !isempty(dual_order) && !isempty(regular_order)
        return tuple(dual_order..., regular_order...)
    elseif !isempty(dual_order)
        return tuple(dual_order...)
    elseif !isempty(regular_order)
        return tuple(regular_order...)
    else
        # If no sites are present, return an empty tuple
        return ()
    end
end
```