### PR TITLE
Implement Eigendecomposition

### DIFF
--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -243,3 +243,7 @@ function __expand_repeat(array, axis, size)
 end
 
 LinearAlgebra.opnorm(x::Tensor, p::Real) = opnorm(parent(x), p)
+
+LinearAlgebra.det(x::Tensor{T,2}) where {T} = det(parent(x))
+LinearAlgebra.logdet(x::Tensor{T,2}) where {T} = logdet(parent(x))
+LinearAlgebra.tr(x::Tensor{T,2}) where {T} = tr(parent(x))

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -641,6 +641,13 @@ contract(t::Tensor, tn::AbstractTensorNetwork; kwargs...) = contract(tn, t; kwar
     return contract(intermediates...; dims=suminds(path))
 end
 
+function LinearAlgebra.eigen!(tn::AbstractTensorNetwork; left_inds=Symbol[], right_inds=Symbol[], kwargs...)
+    tensor = tn[left_inds ∪ right_inds...]
+    (; U, Λ, U⁻¹) = eigen(tensor; left_inds, right_inds, kwargs...)
+    replace!(tn, tensor => TensorNetwork([U, Λ, U⁻¹]))
+    return tn
+end
+
 function LinearAlgebra.svd!(tn::AbstractTensorNetwork; left_inds=Symbol[], right_inds=Symbol[], kwargs...)
     tensor = tn[left_inds ∪ right_inds...]
     U, s, Vt = svd(tensor; left_inds, right_inds, kwargs...)


### PR DESCRIPTION
This PR implements `LinearAlgebra.eigen` (and related methods, `eigvals` and `eigvecs`) for `Tensor`, and `LinearAlgebra.eigen!` for `AbstractTensorNetwork`.

The design of this implementation is somewhat more similar to how Julia implements factorizations: there is this new `TensorEigen` object which `eigen(::Tensor)` returns. We could have used `LinearAlgebra.Eigen` (which is the return type of `eigen`), but it doesn't store the right indices required to construct $U\^{-1}$.

The following destructuring syntax is supported:
```julia
A = Tensor(normalize!(rand(2,2)), [:i, :j])

Λ, U = eigen(A)
(; U⁻¹) = eigen(A)
(; Uinv) = eigen(A)
(; U, Λ, U⁻¹) = eigen(A)
```