### PR TITLE
Replace hard-coded `truncate!` `threshold` with the epsilon value of the chain's `eltype`

### DIFF
--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -393,7 +393,7 @@ function truncate!(qtn::Chain, bond; threshold::Union{Nothing,Real}=nothing, max
 
     # remove 0s from spectrum
     if isnothing(threshold)
-        threshold = eps(eltype(qtn))
+        threshold = wrap_eps(eltype(qtn))
     end
 
     filter!(extent) do i

--- a/src/Ansatz/Chain.jl
+++ b/src/Ansatz/Chain.jl
@@ -393,7 +393,7 @@ function truncate!(qtn::Chain, bond; threshold::Union{Nothing,Real}=nothing, max
 
     # remove 0s from spectrum
     if isnothing(threshold)
-        threshold = 1e-16
+        threshold = eps(eltype(qtn))
     end
 
     filter!(extent) do i

--- a/src/Helpers.jl
+++ b/src/Helpers.jl
@@ -48,4 +48,4 @@ resetindex!(gen::IndexCounter) = letter(Threads.atomic_xchg!(gen.counter, 1))
 # eps wrapper so it handles Complex numbers
 # if is Complex, extract the parametric type and get the eps of that
 wrap_eps(x) = eps(x)
-wrap_eps(::Type{Complex{T}}) where T = eps(T)
+wrap_eps(::Type{Complex{T}}) where {T} = eps(T)

--- a/src/Helpers.jl
+++ b/src/Helpers.jl
@@ -44,3 +44,7 @@ function nextindex!(gen::IndexCounter)
     return letter(Threads.atomic_add!(gen.counter, 1))
 end
 resetindex!(gen::IndexCounter) = letter(Threads.atomic_xchg!(gen.counter, 1))
+
+# eps wrapper so it handles Complex numbers
+# if is Complex, extract the parametric type and get the eps of that
+wrap_eps(eltype) = eltype <: Real ? eps(eltype) : eps(first(eltype.parameters))

--- a/src/Helpers.jl
+++ b/src/Helpers.jl
@@ -47,4 +47,5 @@ resetindex!(gen::IndexCounter) = letter(Threads.atomic_xchg!(gen.counter, 1))
 
 # eps wrapper so it handles Complex numbers
 # if is Complex, extract the parametric type and get the eps of that
-wrap_eps(eltype) = eltype <: Real ? eps(eltype) : eps(first(eltype.parameters))
+wrap_eps(x) = eps(x)
+wrap_eps(::Type{Complex{T}}) = eps(T)

--- a/src/Helpers.jl
+++ b/src/Helpers.jl
@@ -48,4 +48,4 @@ resetindex!(gen::IndexCounter) = letter(Threads.atomic_xchg!(gen.counter, 1))
 # eps wrapper so it handles Complex numbers
 # if is Complex, extract the parametric type and get the eps of that
 wrap_eps(x) = eps(x)
-wrap_eps(::Type{Complex{T}}) = eps(T)
+wrap_eps(::Type{Complex{T}}) where T = eps(T)


### PR DESCRIPTION
### Summary
This PR modifies the previously hard-coded threshold inside the `truncate!` function, which was fixed to `1e-16`, to the proper epsilon value of the chain's `eltype`, making it more flexible and general.