### PR TITLE
Avoid in-place operations in `adjoint` and `conj` functions

### DIFF
--- a/src/Quantum.jl
+++ b/src/Quantum.jl
@@ -335,7 +335,21 @@ end
 
 Returns the adjoint of a [`Quantum`](@ref) Tensor Network; i.e. the conjugate Tensor Network with the inputs and outputs swapped.
 """
-Base.adjoint(tn::AbstractQuantum) = adjoint!(deepcopy(tn))
+function Base.adjoint(tn::AbstractQuantum)
+    tn = conj(tn)
+
+    # update site information
+    oldsites = copy(Quantum(tn).sites)
+    empty!(Quantum(tn).sites)
+    for (site, index) in oldsites
+        addsite!(tn, site', index)
+    end
+
+    # rename inner indices
+    replace!(tn, map(i -> i => Symbol(i, "'"), inds(tn; set=:virtual)))
+
+    return tn
+end
 
 function LinearAlgebra.adjoint!(tn::AbstractQuantum)
     conj!(tn)

--- a/src/Quantum.jl
+++ b/src/Quantum.jl
@@ -335,26 +335,12 @@ end
 
 Returns the adjoint of a [`Quantum`](@ref) Tensor Network; i.e. the conjugate Tensor Network with the inputs and outputs swapped.
 """
-function Base.adjoint(tn::AbstractQuantum)
-    tn = conj(tn)
+Base.adjoint(tn::AbstractQuantum) = adjoint_sites!(conj(tn))
 
-    # update site information
-    oldsites = copy(Quantum(tn).sites)
-    empty!(Quantum(tn).sites)
-    for (site, index) in oldsites
-        addsite!(tn, site', index)
-    end
+LinearAlgebra.adjoint!(tn::AbstractQuantum) = adjoint_sites!(conj!(tn))
 
-    # rename inner indices
-    replace!(tn, map(i -> i => Symbol(i, "'"), inds(tn; set=:virtual)))
-
-    return tn
-end
-
-function LinearAlgebra.adjoint!(tn::AbstractQuantum)
-    conj!(tn)
-
-    # update site information
+# update site information and rename inner indices
+function adjoint_sites!(tn::AbstractQuantum)
     oldsites = copy(Quantum(tn).sites)
     empty!(Quantum(tn).sites)
     for (site, index) in oldsites

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -87,7 +87,17 @@ end
 
 Base.eltype(tn::AbstractTensorNetwork) = promote_type(eltype.(tensors(tn))...)
 
-Base.conj(tn::AbstractTensorNetwork) = conj!(deepcopy(tn))
+"""
+    conj(tn::AbstractTensorNetwork)
+
+Return a copy of the [`AbstractTensorNetwork`](@ref) with all tensors conjugated.
+"""
+function Base.conj(tn::AbstractTensorNetwork)
+    tn = copy(tn)
+    replace!(tn, Pair.(tensors(tn), conj.(tensors(tn))))
+    return tn
+end
+
 function Base.conj!(tn::AbstractTensorNetwork)
     foreach(conj!, tensors(tn))
     return tn

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -94,7 +94,7 @@ Return a copy of the [`AbstractTensorNetwork`](@ref) with all tensors conjugated
 """
 function Base.conj(tn::AbstractTensorNetwork)
     tn = copy(tn)
-    replace!(tn, Pair.(tensors(tn), conj.(tensors(tn))))
+    replace!(tn, tensors(tn) .=> conj.(tensors(tn)))
     return tn
 end
 

--- a/test/Quantum_test.jl
+++ b/test/Quantum_test.jl
@@ -55,6 +55,25 @@
     @test_throws ErrorException Quantum(tn, Dict(site"1" => :j))
     @test_throws ErrorException Quantum(tn, Dict(site"1" => :i))
 
+    @testset "Base.adjoint" begin
+        _tensors = Tensor[
+            Tensor(rand(ComplexF64, 2, 4, 2), [:i, :link, :j]), Tensor(rand(ComplexF64, 2, 4, 2), [:k, :link, :l])
+        ]
+        tn = TensorNetwork(_tensors)
+        qtn = Quantum(tn, Dict(site"1" => :i, site"2" => :k, site"1'" => :j, site"2'" => :l))
+
+        adjoint_qtn = adjoint(qtn)
+
+        @test nsites(adjoint_qtn; set=:inputs) == nsites(adjoint_qtn; set=:outputs) == 2
+        @test issetequal(sites(adjoint_qtn), [site"1", site"2", site"1'", site"2'"])
+        @test socket(adjoint_qtn) == Operator()
+        @test inds(adjoint_qtn; at=site"1'") == :i # now the indices are flipped
+        @test inds(adjoint_qtn; at=site"1") == :j
+        @test inds(adjoint_qtn; at=site"2'") == :k
+        @test inds(adjoint_qtn; at=site"2") == :l
+        @test isapprox(tensors(adjoint_qtn), replace.(conj.(_tensors), :link => Symbol(:link, "'")))
+    end
+
     @testset "reindex!" begin
         @testset "manual indices" begin
             # mps-like tensor network

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -643,6 +643,14 @@
         @test issetequal(inds(projvirttn), [:i, :k])
     end
 
+    @testset "Base.conj" begin
+        tensor1 = Tensor(rand(ComplexF64, 3, 4), (:i, :j))
+        tensor2 = Tensor(rand(ComplexF64, 4, 5), (:j, :k))
+        complextn = TensorNetwork([tensor1, tensor2])
+
+        @test -imag.(tensors(complextn)) == imag.(tensors(conj(complextn)))
+    end
+
     @testset "Base.conj!" begin
         @testset "for complex" begin
             tensor1 = Tensor(rand(ComplexF64, 3, 4), (:i, :j))


### PR DESCRIPTION
### Summary
This PR modifies the `adjoint` and `conj` functions for `AbstractQuantum` and `AbstractTensorNetwork` types to prevent errors when tensors contain immutable arrays. Instead of performing in-place operations, the functions now return a modified copy of the input.

Some tensors within a `TensorNetwork` may have immutable arrays in their parent structures. Performing in-place operations like `conj!` or `adjoint!` on these tensors can lead to errors because immutable arrays do not support the `setindex!` operation required for in-place modification. 

### Example
```julia
julia> using Tenet

julia> using YaoBlocks

julia> c = YaoBlocks.chain(2)

julia> c = YaoBlocks.chain(2, c, put(1 => X))

julia> c = YaoBlocks.chain(2, c, put(2 => X))

julia> c = YaoBlocks.chain(2, c, put(1 => X))

julia> allzeros = Quantum(Product(fill([1, 0], 2)))
Quantum (inputs=0, outputs=2)

julia> state_qtn = merge(allzeros, Quantum(c))
Quantum (inputs=0, outputs=2)
```

##### Before this PR:
```julia
julia> state_qtn'
ERROR: BoundsError: attempt to access 2×2 LuxurySparse.SDPermMatrix{ComplexF64, Int64, Vector{ComplexF64}, Vector{Int64}} at index [1, 1]
Stacktrace: ...
```

##### Now:
```julia
julia> state_qtn'
Quantum (inputs=2, outputs=0)
```