### PR TITLE
Fix `replace!` function when replacing a `Tensor` with itself in `pair` argument

### DIFF
--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -438,7 +438,7 @@ function Base.replace!(tn::AbstractTensorNetwork, pair::Pair{<:Tensor,<:Tensor})
     tn = TensorNetwork(tn)
     old_tensor, new_tensor = pair
 
-    old_tensor == new_tensor && return tn
+    old_tensor === new_tensor && return tn
 
     issetequal(inds(new_tensor), inds(old_tensor)) || throw(ArgumentError("replacing tensor indices don't match"))
 

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -437,6 +437,9 @@ end
 function Base.replace!(tn::AbstractTensorNetwork, pair::Pair{<:Tensor,<:Tensor})
     tn = TensorNetwork(tn)
     old_tensor, new_tensor = pair
+
+    old_tensor == new_tensor && return tn
+
     issetequal(inds(new_tensor), inds(old_tensor)) || throw(ArgumentError("replacing tensor indices don't match"))
 
     push!(tn, new_tensor)

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -486,7 +486,7 @@
                 end
             end
 
-            @testset "TensorNetwork with tensors with equal indices" begin
+            @testset "TensorNetwork with tensors of equal indices" begin
                 A = Tensor(rand(2, 2), (:u, :w))
                 B = Tensor(rand(2, 2), (:u, :w))
                 tn = TensorNetwork([A, B])
@@ -503,7 +503,7 @@
                 @test issetequal(tensors(tn), [new_tensor, B])
             end
 
-            @testset "Chain of replacements" begin
+            @testset "Sequence of replacements" begin
                 A = Tensor(zeros(2, 2), (:i, :j))
                 B = Tensor(zeros(2, 2), (:j, :k))
                 C = Tensor(zeros(2, 2), (:k, :l))
@@ -518,7 +518,7 @@
                 @test issetequal(tensors(tn), [new_tensor2, B, C])
             end
 
-            @testset "Same Tensor in pair argument" begin
+            @testset "Replace with itself" begin
                 A = Tensor(rand(2, 2), (:i, :j))
                 B = Tensor(rand(2, 2), (:j, :k))
                 C = Tensor(rand(2, 2), (:k, :l))

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -459,60 +459,64 @@
         end
 
         @testset "replace tensors" begin
-            t_ij = Tensor(zeros(2, 2), (:i, :j))
-            t_ik = Tensor(zeros(2, 2), (:i, :k))
-            t_ilm = Tensor(zeros(2, 2, 2), (:i, :l, :m))
-            t_lm = Tensor(zeros(2, 2), (:l, :m))
-            tn = TensorNetwork([t_ij, t_ik, t_ilm, t_lm])
+            @testset "Basic replacement" begin
+                t_ij = Tensor(zeros(2, 2), (:i, :j))
+                t_ik = Tensor(zeros(2, 2), (:i, :k))
+                t_ilm = Tensor(zeros(2, 2, 2), (:i, :l, :m))
+                t_lm = Tensor(zeros(2, 2), (:l, :m))
+                tn = TensorNetwork([t_ij, t_ik, t_ilm, t_lm])
 
-            old_tensor = t_lm
+                old_tensor = t_lm
 
-            @test_throws ArgumentError begin
-                new_tensor = Tensor(rand(2, 2), (:a, :b))
+                @test_throws ArgumentError begin
+                    new_tensor = Tensor(rand(2, 2), (:a, :b))
+                    replace!(tn, old_tensor => new_tensor)
+                end
+
+                new_tensor = Tensor(rand(2, 2), (:l, :m))
                 replace!(tn, old_tensor => new_tensor)
+
+                @test new_tensor === only(filter(t -> issetequal(inds(t), [:l, :m]), tensors(tn)))
+
+                # Check if connections are maintained
+                for ind in inds(new_tensor)
+                    tensors_with_ind = tn.indexmap[ind]
+                    @test new_tensor ∈ tensors_with_ind
+                    @test !(old_tensor ∈ tensors_with_ind)
+                end
             end
 
-            new_tensor = Tensor(rand(2, 2), (:l, :m))
-            replace!(tn, old_tensor => new_tensor)
+            @testset "TensorNetwork with tensors with equal indices" begin
+                A = Tensor(rand(2, 2), (:u, :w))
+                B = Tensor(rand(2, 2), (:u, :w))
+                tn = TensorNetwork([A, B])
 
-            @test new_tensor === only(filter(t -> issetequal(inds(t), [:l, :m]), tensors(tn)))
+                new_tensor = Tensor(rand(2, 2), (:u, :w))
 
-            # Check if connections are maintained
-            for ind in inds(new_tensor)
-                tensors_with_ind = tn.indexmap[ind]
-                @test new_tensor ∈ tensors_with_ind
-                @test !(old_tensor ∈ tensors_with_ind)
+                replace!(tn, B => new_tensor)
+                @test A ∈ tensors(tn)
+                @test new_tensor ∈ tensors(tn)
+
+                tn = TensorNetwork([A, B])
+                replace!(tn, A => new_tensor)
+
+                @test issetequal(tensors(tn), [new_tensor, B])
             end
 
-            # New tensor network with two tensors with the same inds
-            A = Tensor(rand(2, 2), (:u, :w))
-            B = Tensor(rand(2, 2), (:u, :w))
-            tn = TensorNetwork([A, B])
+            @testset "Chain of replacements" begin
+                A = Tensor(zeros(2, 2), (:i, :j))
+                B = Tensor(zeros(2, 2), (:j, :k))
+                C = Tensor(zeros(2, 2), (:k, :l))
+                tn = TensorNetwork([A, B, C])
 
-            new_tensor = Tensor(rand(2, 2), (:u, :w))
+                @test_throws ArgumentError replace!(tn, A => B, B => C, C => A)
 
-            replace!(tn, B => new_tensor)
-            @test A ∈ tensors(tn)
-            @test new_tensor ∈ tensors(tn)
+                new_tensor = Tensor(rand(2, 2), (:i, :j))
+                new_tensor2 = Tensor(ones(2, 2), (:i, :j))
 
-            tn = TensorNetwork([A, B])
-            replace!(tn, A => new_tensor)
-
-            @test issetequal(tensors(tn), [new_tensor, B])
-
-            # Test chain of replacements
-            A = Tensor(zeros(2, 2), (:i, :j))
-            B = Tensor(zeros(2, 2), (:j, :k))
-            C = Tensor(zeros(2, 2), (:k, :l))
-            tn = TensorNetwork([A, B, C])
-
-            @test_throws ArgumentError replace!(tn, A => B, B => C, C => A)
-
-            new_tensor = Tensor(rand(2, 2), (:i, :j))
-            new_tensor2 = Tensor(ones(2, 2), (:i, :j))
-
-            replace!(tn, A => new_tensor, new_tensor => new_tensor2)
-            @test issetequal(tensors(tn), [new_tensor2, B, C])
+                replace!(tn, A => new_tensor, new_tensor => new_tensor2)
+                @test issetequal(tensors(tn), [new_tensor2, B, C])
+            end
 
             @testset "Same Tensor in pair argument" begin
                 A = Tensor(rand(2, 2), (:i, :j))

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -478,41 +478,52 @@
             @test new_tensor === only(filter(t -> issetequal(inds(t), [:l, :m]), tensors(tn)))
 
             # Check if connections are maintained
-            # for label in inds(new_tensor)
-            #     index = tn.inds[label]
-            #     @test new_tensor in index.links
-            #     @test !(old_tensor in index.links)
-            # end
+            for ind in inds(new_tensor)
+                tensors_with_ind = tn.indexmap[ind]
+                @test new_tensor ∈ tensors_with_ind
+                @test !(old_tensor ∈ tensors_with_ind)
+            end
 
             # New tensor network with two tensors with the same inds
-            # A = Tensor(rand(2, 2), (:u, :w))
-            # B = Tensor(rand(2, 2), (:u, :w))
-            # tn = TensorNetwork([A, B])
+            A = Tensor(rand(2, 2), (:u, :w))
+            B = Tensor(rand(2, 2), (:u, :w))
+            tn = TensorNetwork([A, B])
 
-            # new_tensor = Tensor(rand(2, 2), (:u, :w))
+            new_tensor = Tensor(rand(2, 2), (:u, :w))
 
-            # replace!(tn, B => new_tensor)
-            # @test A === tensors(tn)[1]
-            # @test new_tensor === tensors(tn)[2]
+            replace!(tn, B => new_tensor)
+            @test A ∈ tensors(tn)
+            @test new_tensor ∈ tensors(tn)
 
-            # tn = TensorNetwork([A, B])
-            # replace!(tn, A => new_tensor)
+            tn = TensorNetwork([A, B])
+            replace!(tn, A => new_tensor)
 
-            # @test issetequal(tensors(tn), [new_tensor, B])
+            @test issetequal(tensors(tn), [new_tensor, B])
 
-            # # Test chain of replacements
-            # A = Tensor(zeros(2, 2), (:i, :j))
-            # B = Tensor(zeros(2, 2), (:j, :k))
-            # C = Tensor(zeros(2, 2), (:k, :l))
-            # tn = TensorNetwork([A, B, C])
+            # Test chain of replacements
+            A = Tensor(zeros(2, 2), (:i, :j))
+            B = Tensor(zeros(2, 2), (:j, :k))
+            C = Tensor(zeros(2, 2), (:k, :l))
+            tn = TensorNetwork([A, B, C])
 
-            # @test_throws ArgumentError replace!(tn, A => B, B => C, C => A)
+            @test_throws ArgumentError replace!(tn, A => B, B => C, C => A)
 
-            # new_tensor = Tensor(rand(2, 2), (:i, :j))
-            # new_tensor2 = Tensor(ones(2, 2), (:i, :j))
+            new_tensor = Tensor(rand(2, 2), (:i, :j))
+            new_tensor2 = Tensor(ones(2, 2), (:i, :j))
 
-            # replace!(tn, A => new_tensor, new_tensor => new_tensor2)
-            # @test issetequal(tensors(tn), [new_tensor2, B, C])
+            replace!(tn, A => new_tensor, new_tensor => new_tensor2)
+            @test issetequal(tensors(tn), [new_tensor2, B, C])
+
+            @testset "Same Tensor in pair argument" begin
+                A = Tensor(rand(2, 2), (:i, :j))
+                B = Tensor(rand(2, 2), (:j, :k))
+                C = Tensor(rand(2, 2), (:k, :l))
+                tn = TensorNetwork([A, B, C])
+
+                replace!(tn, A => A)
+
+                @test issetequal(tensors(tn), [A, B, C])
+            end
         end
 
         @testset "replace tensors by tensor network" begin


### PR DESCRIPTION
### Summary
This PR resolves #225 by fixing the problem with `replace!` when the same `Tensor` appears in both positions of the `pair` argument. Previously, since we did not have any specific check for this case, the `replace!` function had a `push!` that did not add the tensor since it was already present, but then, because we had a `delete!` after the `push!`, the `Tensor` got deleted.

We fixed this problem by adding a condition in the `replace!` function that checks if the two tensors are equal, and if they are, the function returns the `TensorNetwork` without changes.

Additionally (and importantly @bsc-quantic/software !), this PR also fixes the commented-out tests for the `replace!` function, and we have extended these tests to cover the specific case that this PR addresses.