### PR TITLE
Fix `conj` to use `deepcopy` instead of `copy`

### DIFF
--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -94,7 +94,7 @@ Base.eltype(tn::AbstractTensorNetwork) = promote_type(eltype.(tensors(tn))...)
 Return a copy of the [`AbstractTensorNetwork`](@ref) with all tensors conjugated.
 """
 function Base.conj(tn::AbstractTensorNetwork)
-    tn = copy(tn)
+    tn = deepcopy(tn)
     replace!(tn, tensors(tn) .=> conj.(tensors(tn)))
     return tn
 end


### PR DESCRIPTION
### Summary
In this PR, we change `Base.conj` function to use `deepcopy` instead of `copy` to prevent errors when manipulating tensor networks within an `@unsafe_region` macro block.

The regular `copy` leads to problem since it calls `TensorNetworks(tensors(tn))`, which throws an error since there are inconsistent indices. Before the recent commit a2419673fbb1b6c7f1cf86f5b771efb79a7dd8e5 that refactored the `conj` and `adjoint` functions, we also had a `deepcopy` inside `conj` which prevent this problem.

### Example
With this PR, we can do something like the following code without any problem:
```julia
julia> using Tenet

julia> tn = TensorNetwork([
           Tensor(ones(2, 2), [:a, :b]),
           Tensor(ones(2, 2), [:b, :c])
           ])
TensorNetwork (#tensors=2, #inds=3)

julia> Tenet.@unsafe_region tn begin
           c = Tensor(ones(3, 2), [:c, :d])

           push!(tn, c)
           conj(tn)
           pop!(tn, c)
       end
3×2 Tensor{Float64, 2, Matrix{Float64}}:
 1.0  1.0
 1.0  1.0
 1.0  1.0
```