### PR TITLE
Refactor `@unsafe_region` macro

### DIFF
--- a/src/Helpers.jl
+++ b/src/Helpers.jl
@@ -51,7 +51,7 @@ wrap_eps(x) = eps(x)
 wrap_eps(::Type{Complex{T}}) where {T} = eps(T)
 
 struct UnsafeScope
-    refs::Vector{WeakRef} # List of weak references
+    refs::Vector{WeakRef}
 
     UnsafeScope() = new(Vector{WeakRef}())
 end

--- a/src/Helpers.jl
+++ b/src/Helpers.jl
@@ -49,3 +49,11 @@ resetindex!(gen::IndexCounter) = letter(Threads.atomic_xchg!(gen.counter, 1))
 # if is Complex, extract the parametric type and get the eps of that
 wrap_eps(x) = eps(x)
 wrap_eps(::Type{Complex{T}}) where {T} = eps(T)
+
+struct UnsafeContext
+    refs::Vector{WeakRef} # List of weak references
+
+    UnsafeContext() = new(Vector{WeakRef}())
+end
+
+Base.values(uc::UnsafeContext) = map(x -> x.value, uc.refs)

--- a/src/Helpers.jl
+++ b/src/Helpers.jl
@@ -50,10 +50,10 @@ resetindex!(gen::IndexCounter) = letter(Threads.atomic_xchg!(gen.counter, 1))
 wrap_eps(x) = eps(x)
 wrap_eps(::Type{Complex{T}}) where {T} = eps(T)
 
-struct UnsafeContext
+struct UnsafeScope
     refs::Vector{WeakRef} # List of weak references
 
-    UnsafeContext() = new(Vector{WeakRef}())
+    UnsafeScope() = new(Vector{WeakRef}())
 end
 
-Base.values(uc::UnsafeContext) = map(x -> x.value, uc.refs)
+Base.values(uc::UnsafeScope) = map(x -> x.value, uc.refs)

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -41,9 +41,10 @@ struct TensorNetwork <: AbstractTensorNetwork
     tensormap::IdDict{Tensor,Vector{Symbol}}
 
     sorted_tensors::CachedField{Vector{Tensor}}
-    check_index_sizes::Ref{Bool}
+    unsafe::Ref{Union{Nothing,UnsafeContext}}
 
-    function TensorNetwork(tensors; check_index_sizes::Union{Nothing,Bool}=nothing)
+    # TODO: Find a way to remove the `unsafe` keyword argument from the constructor
+    function TensorNetwork(tensors; unsafe::Union{Nothing,UnsafeContext}=nothing)
         tensormap = IdDict{Tensor,Vector{Symbol}}(tensor => inds(tensor) for tensor in tensors)
 
         indexmap = reduce(tensors; init=Dict{Symbol,Vector{Tensor}}()) do dict, tensor
@@ -54,25 +55,25 @@ struct TensorNetwork <: AbstractTensorNetwork
             dict
         end
 
-        if check_index_sizes === nothing || check_index_sizes == true
+        if isnothing(unsafe) # If there is not an active UnsafeContext, check for index sizes
             for ind in keys(indexmap) # Check for inconsistent index dimensions
                 dims = map(tensor -> size(tensor, ind), indexmap[ind])
                 length(unique(dims)) == 1 ||
                     throw(DimensionMismatch("Index $(ind) has inconsistent dimension: $(dims)"))
             end
 
-            return new(indexmap, tensormap, CachedField{Vector{Tensor}}(), Ref(true))
+            return new(indexmap, tensormap, CachedField{Vector{Tensor}}(), Ref{Union{Nothing,UnsafeContext}}(nothing))
         end
 
-        return new(indexmap, tensormap, CachedField{Vector{Tensor}}(), Ref(false))
+        return new(indexmap, tensormap, CachedField{Vector{Tensor}}(), Ref{Union{Nothing,UnsafeContext}}(unsafe))
     end
 end
 
 TensorNetwork() = TensorNetwork(Tensor[])
 TensorNetwork(tn::TensorNetwork) = tn
 
-function set_unsafe_context!(tn::TensorNetwork, uc::Bool)
-    tn.check_index_sizes[] = uc
+function set_unsafe_context!(tn::TensorNetwork, uc::Union{Nothing,UnsafeContext})
+    tn.unsafe[] = uc
     return tn
 end
 
@@ -82,12 +83,11 @@ end
 Return a shallow copy of a [`TensorNetwork`](@ref).
 """
 function Base.copy(tn::TensorNetwork)
-    new_tn = TensorNetwork(tensors(tn); check_index_sizes=tn.check_index_sizes[])
+    new_tn = TensorNetwork(tensors(tn); unsafe=tn.unsafe[])
 
-    # Check if there's an active UnsafeContext with tn in it
-    uc = current_unsafe_context()
-    if uc !== nothing && tn ∈ uc
-        push!(uc.refs, WeakRef(new_tn)) # Register the new copy in the UnsafeContext
+    # Check if there's an active UnsafeContext in the current tn
+    if !isnothing(tn.unsafe[])
+        push!(tn.unsafe[].refs, WeakRef(new_tn)) # Register the new copy in the UnsafeContext
     end
 
     return new_tn
@@ -281,18 +281,6 @@ function __check_index_sizes(tn)
     return true
 end
 
-struct UnsafeContext
-    refs::Vector{WeakRef}  # List of weak references
-
-    UnsafeContext() = new(Vector{WeakRef}())
-end
-
-Base.values(uc::UnsafeContext) = map(x -> x.value, uc.refs)
-
-# Global stack to manage nested unsafe contexts
-const _unsafe_context_stack = Ref{Vector{UnsafeContext}}(Vector{UnsafeContext}())
-
-Base.in(tn::TensorNetwork, tnstack::Vector{TensorNetwork}) = any(tn_ -> tn == tn_, tnstack)
 Base.in(tn::TensorNetwork, ucstack::Vector{UnsafeContext}) = any(uc -> tn ∈ values(uc), ucstack)
 Base.in(tn::TensorNetwork, uc::UnsafeContext) = tn ∈ values(uc)
 
@@ -311,16 +299,12 @@ macro unsafe_region(tn_sym, block)
         quote
             local old = copy($tn_sym)
 
-            # Create a new UnsafeContext and push it onto the stack
+            # Create a new UnsafeContext and set it to the current tn
             local _uc = Tenet.UnsafeContext()
-            push!(Tenet._unsafe_context_stack[], _uc)
-
-            # Set check_index_sizes to false for the passed tensor network
-            Tenet.set_unsafe_context!($tn_sym, false)
-            # $tn_sym.check_index_sizes[] = false
+            Tenet.set_unsafe_context!($tn_sym, _uc)
 
             # Register the tensor network in the context
-            push!(_uc.refs, WeakRef($tn_sym))
+            push!($tn_sym.unsafe[].refs, WeakRef($tn_sym))
 
             e = nothing
             try
@@ -331,19 +315,19 @@ macro unsafe_region(tn_sym, block)
             finally
                 if e === nothing
                     # Perform checks of registered tensor networks
-                    for ref in _uc.refs
+                    for ref in $tn_sym.unsafe[].refs
                         tn = ref.value
-                        if tn !== nothing
+                        if tn !== nothing && tn ∈ values($tn_sym.unsafe[])
                             if !Tenet.__check_index_sizes(tn)
                                 $(tn_sym) = old
-                                pop!(Tenet._unsafe_context_stack[])
+
+                                # Set `unsafe` field to `nothing`
+                                Tenet.set_unsafe_context!($tn_sym, nothing)
+
                                 throw(DimensionMismatch("Inconsistent size of indices"))
                             end
                         end
                     end
-
-                    # Pop the UnsafeContext from the stack
-                    pop!(Tenet._unsafe_context_stack[])
                 end
             end
         end,
@@ -361,9 +345,8 @@ function Base.push!(tn::AbstractTensorNetwork, tensor::Tensor)
     tn = TensorNetwork(tn)
     tensor ∈ keys(tn.tensormap) && return tn
 
-    # Check if there's an active UnsafeContext with tn in it
-    uc = current_unsafe_context()
-    if uc === nothing || tn ∉ uc  # Only check index sizes if we are not in an unsafe region
+    # Check if there's an active UnsafeContext in the tn
+    if isnothing(tn.unsafe[]) # Only check index sizes if we are not in an unsafe region
         for i in Iterators.filter(i -> size(tn, i) != size(tensor, i), inds(tensor) ∩ inds(tn))
             throw(
                 DimensionMismatch("size(tensor,$i)=$(size(tensor,i)) but should be equal to size(tn,$i)=$(size(tn,i))")

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -55,7 +55,7 @@ struct TensorNetwork <: AbstractTensorNetwork
             dict
         end
 
-                # Check index size consistency if not inside an `UnsafeScope`
+        # Check index size consistency if not inside an `UnsafeScope`
         if isnothing(unsafe) # If there is not an active UnsafeScope, check for index sizes
             for ind in keys(indexmap)
                 dims = map(tensor -> size(tensor, ind), indexmap[ind])

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -54,7 +54,7 @@ struct TensorNetwork <: AbstractTensorNetwork
             dict
         end
 
-        if check_index_sizes === nothing && check_index_sizes == true
+        if check_index_sizes === nothing || check_index_sizes == true
             for ind in keys(indexmap) # Check for inconsistent index dimensions
                 dims = map(tensor -> size(tensor, ind), indexmap[ind])
                 length(unique(dims)) == 1 ||

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -77,7 +77,8 @@ struct TensorNetwork <: AbstractTensorNetwork
         if check_index_sizes
             for ind in keys(indexmap)
                 dims = map(tensor -> size(tensor, ind), indexmap[ind])
-                length(unique(dims)) == 1 || throw(DimensionMismatch("Index $(ind) has inconsistent dimension: $(dims)"))
+                length(unique(dims)) == 1 ||
+                    throw(DimensionMismatch("Index $(ind) has inconsistent dimension: $(dims)"))
             end
         end
 
@@ -357,7 +358,7 @@ macro unsafe_region(tn_sym, block)
                     pop!(Tenet._unsafe_context_stack[])
                 end
             end
-        end
+        end,
     )
 end
 

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -56,7 +56,7 @@ struct TensorNetwork <: AbstractTensorNetwork
         end
 
         # Check index size consistency if not inside an `UnsafeScope`
-        if isnothing(unsafe) # If there is not an active UnsafeScope, check for index sizes
+        if isnothing(unsafe)
             for ind in keys(indexmap)
                 dims = map(tensor -> size(tensor, ind), indexmap[ind])
                 length(unique(dims)) == 1 ||

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -62,83 +62,47 @@ struct TensorNetwork <: AbstractTensorNetwork
 
         return new(indexmap, tensormap, CachedField{Vector{Tensor}}(), Ref(true))
     end
+
+    function TensorNetwork(tensors, check_index_sizes::Bool)
+        tensormap = IdDict{Tensor,Vector{Symbol}}(tensor => inds(tensor) for tensor in tensors)
+
+        indexmap = reduce(tensors; init=Dict{Symbol,Vector{Tensor}}()) do dict, tensor
+            for index in inds(tensor)
+                # TODO use lambda? `Tensor[]` might be reused
+                push!(get!(dict, index, Tensor[]), tensor)
+            end
+            dict
+        end
+
+        if check_index_sizes
+            for ind in keys(indexmap)
+                dims = map(tensor -> size(tensor, ind), indexmap[ind])
+                length(unique(dims)) == 1 || throw(DimensionMismatch("Index $(ind) has inconsistent dimension: $(dims)"))
+            end
+        end
+
+        return new(indexmap, tensormap, CachedField{Vector{Tensor}}(), Ref(check_index_sizes))
+    end
 end
 
 TensorNetwork() = TensorNetwork(Tensor[])
 TensorNetwork(tn::TensorNetwork) = tn
-
-struct UnsafeContext
-    refs::Vector{WeakRef}  # List of weak references
-
-    UnsafeContext() = new(Vector{WeakRef}())
-end
-
-# Global stack to manage nested unsafe contexts
-const _unsafe_context_stack = Ref{Vector{UnsafeContext}}(Vector{UnsafeContext}())
-
-# Function to get the current UnsafeContext
-function current_unsafe_context()
-    if isempty(Tenet._unsafe_context_stack[])  # Fixed typo here
-        return nothing
-    else
-        return Tenet._unsafe_context_stack[][end]
-    end
-end
-
-# Define the @unsafe_region macro
-macro unsafe_region(tn_sym, block)
-    return esc(quote
-        # Create a new UnsafeContext and push it onto the stack
-        local _uc = Tenet.UnsafeContext()
-        push!(Tenet._unsafe_context_stack[], _uc)
-
-        # Set check_index_sizes to false for the passed tensor network
-        $tn_sym.check_index_sizes[] = false
-
-        # Register the tensor network in the context
-        push!(_uc.refs, WeakRef($tn_sym))
-
-        try
-            # Execute the user-provided block
-            $(block)
-        finally
-            # Perform checks of registered tensor networks
-            for ref in _uc.refs
-                tn = ref.value
-                if tn !== nothing
-                    if !Tenet.__check_index_sizes(tn)
-                        throw(DimensionMismatch("Inconsistent size of indices"))
-                    else
-                        println("tn $tn is consistent")
-                    end
-                end
-            end
-
-            # Pop the UnsafeContext from the stack
-            pop!(Tenet._unsafe_context_stack[])
-        end
-    end)
-end
 
 """
     copy(tn::TensorNetwork)
 
 Return a shallow copy of a [`TensorNetwork`](@ref).
 """
-Base.copy(tn::TensorNetwork) = TensorNetwork(tensors(tn))
-
 function Base.copy(tn::TensorNetwork)
-    new_tn = TensorNetwork(tensors(tn))
+    new_tn = TensorNetwork(tensors(tn), tn.check_index_sizes[])
 
-    # Check if there's an active UnsafeContext
+    # Check if there's an active UnsafeContext with tn in it
     uc = current_unsafe_context()
-    if uc !== nothing
-        # Set check_index_sizes to false
-        new_tn.check_index_sizes[] = false
-
-        # Register the new copy in the UnsafeContext
-        push!(uc.refs, WeakRef(new_tn))
+    if uc !== nothing && tn ∈ uc
+        push!(uc.refs, WeakRef(new_tn)) # Register the new copy in the UnsafeContext
     end
+
+    return new_tn
 end
 
 Base.similar(tn::TensorNetwork) = TensorNetwork(similar.(tensors(tn)))
@@ -329,25 +293,73 @@ function __check_index_sizes(tn)
     return true
 end
 
-# const is_unsafe_region = ScopedValue(false) # global ScopedValue for the unsafe region
+struct UnsafeContext
+    refs::Vector{WeakRef}  # List of weak references
 
-# macro unsafe_region(tn, block)
-#     return esc(
-#         quote
-#             local old = copy($tn)
-#             try
-#                 $with($is_unsafe_region => true) do
-#                     $block
-#                 end
-#             finally
-#                 if !Tenet.__check_index_sizes($tn)
-#                     tn = old
-#                     throw(DimensionMismatch("Inconsistent size of indices"))
-#                 end
-#             end
-#         end,
-#     )
-# end
+    UnsafeContext() = new(Vector{WeakRef}())
+end
+
+Base.values(uc::UnsafeContext) = map(x -> x.value, uc.refs)
+
+# Global stack to manage nested unsafe contexts
+const _unsafe_context_stack = Ref{Vector{UnsafeContext}}(Vector{UnsafeContext}())
+
+Base.in(tn::TensorNetwork, tnstack::Vector{TensorNetwork}) = any(tn_ -> tn === tn_, tnstack)
+Base.in(tn::TensorNetwork, ucstack::Vector{UnsafeContext}) = any(uc -> tn ∈ values(uc), ucstack)
+Base.in(tn::TensorNetwork, uc::UnsafeContext) = tn ∈ values(uc)
+
+# Function to get the current UnsafeContext
+function current_unsafe_context()
+    if isempty(Tenet._unsafe_context_stack[])
+        return nothing
+    else
+        return Tenet._unsafe_context_stack[][end]
+    end
+end
+
+# Define the @unsafe_region macro
+macro unsafe_region(tn_sym, block)
+    return esc(
+        quote
+            local old = copy($tn_sym)
+
+            # Create a new UnsafeContext and push it onto the stack
+            local _uc = Tenet.UnsafeContext()
+            push!(Tenet._unsafe_context_stack[], _uc)
+
+            # Set check_index_sizes to false for the passed tensor network
+            $tn_sym.check_index_sizes[] = false
+
+            # Register the tensor network in the context
+            push!(_uc.refs, WeakRef($tn_sym))
+
+            e = nothing
+            try
+                $(block) # Execute the user-provided block
+            catch e
+                $(tn_sym) = old # Restore the original tensor network in case of an exception
+                rethrow(e)
+            finally
+                if e === nothing
+                    # Perform checks of registered tensor networks
+                    for ref in _uc.refs
+                        tn = ref.value
+                        if tn !== nothing
+                            if !Tenet.__check_index_sizes(tn)
+                                $(tn_sym) = old
+                                pop!(Tenet._unsafe_context_stack[])
+                                throw(DimensionMismatch("Inconsistent size of indices"))
+                            end
+                        end
+                    end
+
+                    # Pop the UnsafeContext from the stack
+                    pop!(Tenet._unsafe_context_stack[])
+                end
+            end
+        end
+    )
+end
 
 """
     push!(tn::AbstractTensorNetwork, tensor::Tensor)
@@ -360,8 +372,9 @@ function Base.push!(tn::AbstractTensorNetwork, tensor::Tensor)
     tn = TensorNetwork(tn)
     tensor ∈ keys(tn.tensormap) && return tn
 
-    # Only check index sizes if we are not in an unsafe region
-    if !is_unsafe_region[]
+    # Check if there's an active UnsafeContext with tn in it
+    uc = current_unsafe_context()
+    if uc === nothing || tn ∉ uc  # Only check index sizes if we are not in an unsafe region
         for i in Iterators.filter(i -> size(tn, i) != size(tensor, i), inds(tensor) ∩ inds(tn))
             throw(
                 DimensionMismatch("size(tensor,$i)=$(size(tensor,i)) but should be equal to size(tn,$i)=$(size(tn,i))")

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -281,7 +281,6 @@ function __check_index_sizes(tn)
     return true
 end
 
-Base.in(tn::TensorNetwork, ucstack::Vector{UnsafeContext}) = any(uc -> tn ∈ values(uc), ucstack)
 Base.in(tn::TensorNetwork, uc::UnsafeContext) = tn ∈ values(uc)
 
 # Function to get the current UnsafeContext

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -54,7 +54,7 @@ struct TensorNetwork <: AbstractTensorNetwork
             dict
         end
 
-        if check_index_sizes !== nothing && check_index_sizes !== false
+        if check_index_sizes === nothing && check_index_sizes == true
             for ind in keys(indexmap) # Check for inconsistent index dimensions
                 dims = map(tensor -> size(tensor, ind), indexmap[ind])
                 length(unique(dims)) == 1 ||

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -731,6 +731,17 @@
                     pop!(tn, tensor)
                 end
 
+                # Double copy should also throw an error:
+                @test_throws DimensionMismatch Tenet.@unsafe_region tn begin
+                    tensor = Tensor(ones(3, 2), [:c, :d])
+                    push!(tn, tensor)
+                    tn2 = copy(tn)
+                    tn3 = copy(tn2)
+                    push!(tn3, tensor)
+                    @test length(tensors(tn)) == 3
+                    pop!(tn, tensor)
+                end
+
                 Tenet.@unsafe_region tn begin # This should not throw an error
                     tensor = Tensor(ones(3, 2), [:c, :d])
                     push!(tn, tensor)

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -715,6 +715,7 @@
                 @test_throws DimensionMismatch Tenet.@unsafe_region tn begin
                     tensor = Tensor(ones(3, 2), [:c, :d])
                     push!(tn, tensor)
+                    tn2 = TensorNetwork([Tensor(ones(2, 2), [:a, :b]), Tensor(ones(2, 2), [:b, :c])])
                     push!(tn2, tensor) # tn2 is not specified in @unsafe_region argument
                     @test length(tensors(tn)) == 3
                     pop!(tn, tensor)
@@ -725,7 +726,7 @@
                     tensor = Tensor(ones(3, 2), [:c, :d])
                     push!(tn, tensor)
                     tn2 = copy(tn)
-                    push!(tn2, tensor)  # tn2 is not specified in @unsafe_region
+                    push!(tn2, tensor)
                     @test length(tensors(tn)) == 3
                     pop!(tn, tensor)
                 end


### PR DESCRIPTION
### Summary
This PR resolves #230 by refactoring the `@unsafe_region` macro. In this PR, we added a new field on the `TensorNetwork` struct `check_index_sizes::Ref{Bool}`. When `true`, there will be no inconsistent-dimension checks on the `push!` functions.

Now, `@unsafe_region` just modifies this value in the `field` of the specific `TensorNetwork` passed in the arguments, and keeps track of all the possible copies created inside the macro block.

### Example
Let's see how we fixed the example we show in #230:
```julia
julia> using Tenet

julia> tn = TensorNetwork([
           Tensor(ones(2, 2), [:a, :b]),
           Tensor(ones(2, 2), [:b, :c])
       ])
TensorNetwork (#tensors=2, #inds=3)

julia> tn2 = copy(tn)
TensorNetwork (#tensors=2, #inds=3)

julia> Tenet.@unsafe_region tn begin # Now it errors properly!
           tensor = Tensor(ones(3, 2), [:c, :d])
           push!(tn, tensor)
           push!(tn2, tensor)  # tn2 is not specified in @unsafe_region
           @test length(tensors(tn)) == 3
           pop!(tn, tensor)
       end
ERROR: DimensionMismatch: size(tensor,c)=3 but should be equal to size(tn,c)=2
Stacktrace:
 [1] push!(tn::TensorNetwork, tensor::Tensor{Float64, 2, Matrix{Float64}})
   @ Tenet ~/git/Tenet.jl/src/TensorNetwork.jl:381
 [2] macro expansion
   @ ./REPL[14]:4 [inlined]
 [3] top-level scope
```

But if instead `tn2` is created inside the macro block:
```julia
julia> tn = TensorNetwork([
                  Tensor(ones(2, 2), [:a, :b]),
                  Tensor(ones(2, 2), [:b, :c])
              ])
TensorNetwork (#tensors=2, #inds=3)

julia> Tenet.@unsafe_region tn begin # Here still errors since at the end `tn2` is inconsistent
                  tensor = Tensor(ones(3, 2), [:c, :d])
                  push!(tn, tensor)
                  tn2 = copy(tn)
                  push!(tn2, tensor)  # tn2 is not specified in @unsafe_region
                  @test length(tensors(tn)) == 3
                  pop!(tn, tensor)
       end
ERROR: DimensionMismatch: Inconsistent size of indices
Stacktrace:
 [1] top-level scope
   @ ~/git/Tenet.jl/src/TensorNetwork.jl:351

julia> Tenet.@unsafe_region tn begin ### No errors thrown!
                  tensor = Tensor(ones(3, 2), [:c, :d])
                  push!(tn, tensor)
                  tn2 = copy(tn)
                  push!(tn2, tensor)  # tn2 is not specified in @unsafe_region
                  @test length(tensors(tn)) == 3
                  pop!(tn, tensor)
                  pop!(tn2, tensor)
       end
3×2 Tensor{Float64, 2, Matrix{Float64}}:
 1.0  1.0
 1.0  1.0
 1.0  1.0
```
So we get the expected correct behavior.
