### PR TITLE
Fix `Quantum` function for `Quac.Gate` type

### DIFF
--- a/ext/TenetQuacExt.jl
+++ b/ext/TenetQuacExt.jl
@@ -4,7 +4,7 @@ using Tenet
 using Quac: Gate, Circuit, lanes, arraytype, Swap
 
 function Tenet.Quantum(gate::Gate)
-    return Tenet.Quantum(arraytype(gate)(gate), [Site.(lanes(gate))..., Site.(lanes(gate); dual=true)...])
+    return Tenet.Quantum(arraytype(gate)(gate), Site[Site.(lanes(gate))..., Site.(lanes(gate); dual=true)...])
 end
 
 Tenet.evolve!(qtn::Ansatz, gate::Gate; kwargs...) = evolve!(qtn, Quantum(gate); kwargs...)

--- a/ext/TenetQuacExt.jl
+++ b/ext/TenetQuacExt.jl
@@ -4,7 +4,7 @@ using Tenet
 using Quac: Gate, Circuit, lanes, arraytype, Swap
 
 function Tenet.Quantum(gate::Gate)
-    return Tenet.Quantum(arraytype(gate)(gate); sites=Site[Site.(lanes(gate))..., Site.(lanes(gate); dual=true)...])
+    return Tenet.Quantum(arraytype(gate)(gate), [Site.(lanes(gate))..., Site.(lanes(gate); dual=true)...])
 end
 
 Tenet.evolve!(qtn::Ansatz, gate::Gate; kwargs...) = evolve!(qtn, Quantum(gate); kwargs...)

--- a/test/integration/Quac_test.jl
+++ b/test/integration/Quac_test.jl
@@ -1,6 +1,19 @@
 @testset "Quac" begin
     using Quac
 
+    @testset "Gate" begin
+        n = 3
+        id_gate = n - 1
+        gate = Quac.Z(id_gate)
+
+        qgate = Quantum(gate)
+
+        @test nsites(qgate; set=:inputs) == 1
+        @test nsites(qgate; set=:outputs) == 1
+        @test issetequal(sites(qgate), [Site(id_gate), Site(id_gate; dual=true)])
+        @test socket(qgate) == Operator()
+    end
+
     @testset "QFT" begin
         n = 3
         qftcirc = Quac.Algorithms.QFT(n)

--- a/test/integration/Quac_test.jl
+++ b/test/integration/Quac_test.jl
@@ -2,8 +2,7 @@
     using Quac
 
     @testset "Gate" begin
-        n = 3
-        id_gate = n - 1
+        id_gate = 2
         gate = Quac.Z(id_gate)
 
         qgate = Quantum(gate)


### PR DESCRIPTION
### Summary
This PR fixes a problem with the `Quantum` function for `Quac.Gate` argument. Before this PR, this function had legacy code from our previous `Dense` structure, which was replaced in PR #223. Specifically, we still had the `sites` kwarg, which is now replaced by the second argument of `Quantum`.

Additionally, in this PR we also add a `@testset` `"Gate"` in the `Quac` integration tests to cover for this issue.