### PR TITLE
Fix `truncate!` function

### DIFF
--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -255,8 +255,8 @@ Truncate the dimension of the virtual `bond`` of an [`Ansatz`](@ref) Tensor Netw
 
   - Either `threshold` or `maxdim` must be provided. If both are provided, `maxdim` is used.
 """
-function truncate!(tn::AbstractAnsatz, bond; threshold=nothing, maxdim=nothing)
-    return truncate!(form(tn), tn, bond; threshold, maxdim)
+function truncate!(tn::AbstractAnsatz, bond; threshold=nothing, maxdim=nothing, kwargs...)
+    return truncate!(form(tn), tn, bond; threshold, maxdim, kwargs...)
 end
 
 """
@@ -315,8 +315,18 @@ function truncate!(::MixedCanonical, tn::AbstractAnsatz, bond; threshold, maxdim
     return truncate!(NonCanonical(), tn, bond; threshold, maxdim, compute_local_svd=true)
 end
 
-function truncate!(::Canonical, tn::AbstractAnsatz, bond; threshold, maxdim)
-    return truncate!(NonCanonical(), tn, bond; threshold, maxdim, compute_local_svd=false)
+"""
+    truncate!(::Canonical, tn::AbstractAnsatz, bond; threshold, maxdim, recanonize=true)
+
+Truncate the dimension of the virtual `bond` of a [`Canonical`](@ref) Tensor Network by keeping the `maxdim` largest
+**Schmidt coefficients** or those larger than `threshold`, and then recanonizes the Tensor Network if `recanonize` is `true`.
+"""
+function truncate!(::Canonical, tn::AbstractAnsatz, bond; threshold, maxdim, recanonize=true)
+    truncate!(NonCanonical(), tn, bond; threshold, maxdim, compute_local_svd=false)
+
+    recanonize && canonize!(tn)
+
+    return tn
 end
 
 overlap(a::AbstractAnsatz, b::AbstractAnsatz) = contract(merge(a, copy(b)'))

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -49,7 +49,7 @@ struct NonCanonical <: Form end
     left of the orthogonality center are left-canonical and the tensors to the right are right-canonical.
 """
 struct MixedCanonical <: Form
-    orthog_center::Union{Site,Vector{Site}}
+    orthog_center::Union{Site,Vector{<:Site}}
 end
 
 """

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -312,7 +312,7 @@ end
 function truncate!(::MixedCanonical, tn::AbstractAnsatz, bond; threshold, maxdim)
     # move orthogonality center to bond
     mixed_canonize!(tn, bond)
-    return truncate!(NonCanonical(), tn, bond; threshold, maxdim, compute_local_svd=false)
+    return truncate!(NonCanonical(), tn, bond; threshold, maxdim, compute_local_svd=true)
 end
 
 function truncate!(::Canonical, tn::AbstractAnsatz, bond; threshold, maxdim)

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -525,9 +525,9 @@ function mixed_canonize!(tn::AbstractMPO, orthog_center)
     end
 
     # center SVD sweep to get singular values
-    for i in (left + 1):(right - 1)
-        canonize_site!(tn, Site(i); direction=:left, method=:svd)
-    end
+    # for i in (left + 1):(right - 1)
+    #     canonize_site!(tn, Site(i); direction=:left, method=:svd)
+    # end
 
     tn.form = MixedCanonical(orthog_center)
 

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -525,7 +525,7 @@ function mixed_canonize!(tn::AbstractMPO, orthog_center)
     end
 
     # center SVD sweep to get singular values
-    for i in left+1:right-1
+    for i in (left + 1):(right - 1)
         canonize_site!(tn, Site(i); direction=:left, method=:svd)
     end
 

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -126,6 +126,13 @@ function MPS(::Canonical, arrays, λ; order=defaultorder(MPS), check=true)
     return mps
 end
 
+"""
+
+    check_form(mps::AbstractMPO)
+
+Check if the tensors in the mps are in the proper [`Form`](@ref).
+
+"""
 check_form(mps::AbstractMPO) = check_form(form(mps), mps)
 
 function check_form(config::MixedCanonical, mps::AbstractMPO)
@@ -150,8 +157,7 @@ end
 
 function check_form(::Canonical, mps::AbstractMPO)
     for i in 1:nsites(mps)
-        if i > 1
-            !isisometry(contract(mps; between=(Site(i - 1), Site(i)), direction=:right), Site(i); dir=:right)
+        if i > 1 && !isisometry(contract(mps; between=(Site(i - 1), Site(i)), direction=:right), Site(i); dir=:right)
             throw(ArgumentError("Can not form a left-canonical tensor in Site($i) from Γ and λ contraction."))
         end
 
@@ -163,6 +169,8 @@ function check_form(::Canonical, mps::AbstractMPO)
 
     return true
 end
+
+check_form(::NonCanonical, mps::AbstractMPO) = true
 
 """
     MPO(arrays::Vector{<:AbstractArray}; order=defaultorder(MPO))

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -127,11 +127,9 @@ function MPS(::Canonical, arrays, λ; order=defaultorder(MPS), check=true)
 end
 
 """
-
     check_form(mps::AbstractMPO)
 
 Check if the tensors in the mps are in the proper [`Form`](@ref).
-
 """
 check_form(mps::AbstractMPO) = check_form(form(mps), mps)
 

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -137,7 +137,7 @@ function check_form(config::MixedCanonical, mps::AbstractMPO)
     orthog_center = config.orthog_center
 
     left, right = if orthog_center isa Site
-        id(orthog_center) .+ (0, 0)
+        id(orthog_center) .+ (0, 0) # So left and right get the same value
     elseif orthog_center isa Vector{<:Site}
         extrema(id.(orthog_center))
     end

--- a/test/MPS_test.jl
+++ b/test/MPS_test.jl
@@ -112,11 +112,11 @@ using LinearAlgebra
         end
 
         @testset "Canonical" begin
-            ψ = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
+            ψ = rand(MPS; n=5, maxdim=16)
             canonize!(ψ)
 
-            truncated = truncate(ψ, [site"2", site"3"]; maxdim=1)
-            @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 1
+            truncated = truncate(ψ, [site"2", site"3"]; maxdim=2)
+            @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 2
         end
 
         @testset "MixedCanonical" begin

--- a/test/MPS_test.jl
+++ b/test/MPS_test.jl
@@ -95,19 +95,36 @@ using LinearAlgebra
     end
 
     @testset "truncate!" begin
-        ψ = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
-        canonize_site!(ψ, Site(2); direction=:right, method=:svd)
+        @testset "NonCanonical" begin
+            ψ = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
+            canonize_site!(ψ, Site(2); direction=:right, method=:svd)
 
-        truncated = truncate(ψ, [site"2", site"3"]; maxdim=1)
-        @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 1
+            truncated = truncate(ψ, [site"2", site"3"]; maxdim=1)
+            @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 1
 
-        singular_values = tensors(ψ; between=(site"2", site"3"))
-        truncated = truncate(ψ, [site"2", site"3"]; threshold=singular_values[2] + 0.1)
-        @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 1
+            singular_values = tensors(ψ; between=(site"2", site"3"))
+            truncated = truncate(ψ, [site"2", site"3"]; threshold=singular_values[2] + 0.1)
+            @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 1
 
-        # If maxdim > size(spectrum), the bond dimension is not truncated
-        truncated = truncate(ψ, [site"2", site"3"]; maxdim=4)
-        @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 2
+            # If maxdim > size(spectrum), the bond dimension is not truncated
+            truncated = truncate(ψ, [site"2", site"3"]; maxdim=4)
+            @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 2
+        end
+
+        @testset "Canonical" begin
+            ψ = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
+            canonize!(ψ)
+
+            truncated = truncate(ψ, [site"2", site"3"]; maxdim=1)
+            @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 1
+        end
+
+        @testset "MixedCanonical" begin
+            ψ = rand(MPS; n=5, maxdim=16)
+
+            truncated = truncate(ψ, [site"2", site"3"]; maxdim=3)
+            @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 3
+        end
     end
 
     @testset "norm" begin
@@ -210,18 +227,34 @@ using LinearAlgebra
     end
 
     @testset "mixed_canonize!" begin
-        ψ = MPS([rand(4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4)])
-        canonized = mixed_canonize(ψ, site"3")
+        @testset "single Site" begin
+            ψ = MPS([rand(4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4)])
+            canonized = mixed_canonize(ψ, site"3")
 
-        @test form(canonized) isa MixedCanonical
-        @test form(canonized).orthog_center == site"3"
+            @test form(canonized) isa MixedCanonical
+            @test form(canonized).orthog_center == site"3"
 
-        @test isisometry(canonized, site"1"; dir=:right)
-        @test isisometry(canonized, site"2"; dir=:right)
-        @test isisometry(canonized, site"4"; dir=:left)
-        @test isisometry(canonized, site"5"; dir=:left)
+            @test isisometry(canonized, site"1"; dir=:right)
+            @test isisometry(canonized, site"2"; dir=:right)
+            @test isisometry(canonized, site"4"; dir=:left)
+            @test isisometry(canonized, site"5"; dir=:left)
 
-        @test contract(canonized) ≈ contract(ψ)
+            @test contract(canonized) ≈ contract(ψ)
+        end
+
+        @testset "multiple Sites" begin
+            ψ = MPS([rand(4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4)])
+            canonized = mixed_canonize(ψ, [site"2", site"3"])
+
+            @test form(canonized) isa MixedCanonical
+            @test form(canonized).orthog_center == [site"2", site"3"]
+
+            @test isisometry(canonized, site"1"; dir=:right)
+            @test isisometry(canonized, site"4"; dir=:left)
+            @test isisometry(canonized, site"5"; dir=:left)
+
+            @test contract(canonized) ≈ contract(ψ)
+        end
     end
 
     @testset "expect" begin

--- a/test/MPS_test.jl
+++ b/test/MPS_test.jl
@@ -230,6 +230,7 @@ using LinearAlgebra
         @testset "single Site" begin
             ψ = MPS([rand(4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4)])
             canonized = mixed_canonize(ψ, site"3")
+            @test Tenet.check_form(canonized)
 
             @test form(canonized) isa MixedCanonical
             @test form(canonized).orthog_center == site"3"
@@ -246,6 +247,7 @@ using LinearAlgebra
             ψ = MPS([rand(4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4)])
             canonized = mixed_canonize(ψ, [site"2", site"3"])
 
+            @test Tenet.check_form(canonized)
             @test form(canonized) isa MixedCanonical
             @test form(canonized).orthog_center == [site"2", site"3"]
 

--- a/test/MPS_test.jl
+++ b/test/MPS_test.jl
@@ -104,6 +104,10 @@ using LinearAlgebra
         singular_values = tensors(ψ; between=(site"2", site"3"))
         truncated = truncate(ψ, [site"2", site"3"]; threshold=singular_values[2] + 0.1)
         @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 1
+
+        # If maxdim > size(spectrum), the bond dimension is not truncated
+        truncated = truncate(ψ, [site"2", site"3"]; maxdim=4)
+        @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 2
     end
 
     @testset "norm" begin


### PR DESCRIPTION
### Summary
This PR resolves a bug found in the `truncate!` function that erroed when `maxdim` kwarg was larger than the `size` of the bond that was about to truncate. In a similar way, it also erroed when the `threshold` was lower than the smaller element in the `spectrum` that was used to truncate.

Moreover, we fixed the `mixed_canonize!` function, since previously did not work as the `truncate!` function expected for `MPS` with `MixedCanonical` forms. We also fixed an unnecessary canonization step in the `truncate!` for `Canonical` forms.

### Example
Without this PR:
```julia
julia> using Tenet; using Test; using LinearAlgebra

julia> gate = Quantum(reshape(LinearAlgebra.I(4), 2, 2, 2, 2), [site"2", site"3", site"2'", site"3'"])
Quantum (inputs=2, outputs=2)

julia> ψ = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2, 2), rand(2, 2)])
MPS (inputs=0, outputs=4)

julia> ψ = deepcopy(ψ)
MPS (inputs=0, outputs=4)

julia> canonize!(ψ)
MPS (inputs=0, outputs=4)

julia> evolved = evolve!(deepcopy(ψ), gate; maxdim=10)
spectrum = [7.129434737170108, 1.2106678577680343, 3.16516617082361e-16, 9.749816418484561e-18]
ERROR: BoundsError: attempt to access 2×2×4 Array{Float64, 3} at index [1:2, 1:2, 1:10]
Stacktrace: ....

julia> evolved = evolve!(deepcopy(ψ), gate; threshold=1e-100)
ERROR: MethodError: no method matching -(::Nothing, ::Int64)
The function `-` exists, but no method is defined for this combination of argument types.

Closest candidates are: ...
```

Everything now works, and we extended the tests to cover for this changes.