### PR TITLE
Enhance `simple_update!` for `MPS` in the `Canonical` form

### DIFF
--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -321,7 +321,7 @@ end
 Truncate the dimension of the virtual `bond` of a [`Canonical`](@ref) Tensor Network by keeping the `maxdim` largest
 **Schmidt coefficients** or those larger than `threshold`, and then recanonizes the Tensor Network if `recanonize` is `true`.
 """
-function truncate!(::Canonical, tn::AbstractAnsatz, bond; threshold, maxdim, recanonize=true)
+function truncate!(::Canonical, tn::AbstractAnsatz, bond; threshold, maxdim, recanonize=false)
     truncate!(NonCanonical(), tn, bond; threshold, maxdim, compute_local_svd=false)
 
     recanonize && canonize!(tn; normalize=true)

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -419,6 +419,9 @@ function simple_update_1site!(ψ::AbstractAnsatz, gate)
     return contract!(ψ, contracting_index)
 end
 
+simple_update_2site!(::MixedCanonical, ψ::AbstractAnsatz, gate; threshold=nothing, maxdim=nothing, renormalize=false) =
+    simple_update_2site!(NonCanonical(), ψ, gate; threshold, maxdim, renormalize)
+
 # TODO remove `renormalize` argument?
 function simple_update_2site!(
     ::NonCanonical, ψ::AbstractAnsatz, gate; threshold=nothing, maxdim=nothing, renormalize=false
@@ -456,7 +459,7 @@ function simple_update_2site!(
 
     # truncate virtual index
     if any(!isnothing, (threshold, maxdim))
-        truncate!(ψ, bond; threshold, maxdim)
+        truncate!(ψ, [bond...]; threshold, maxdim)
         renormalize && normalize!(ψ, bond[1])
     end
 

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -462,8 +462,8 @@ function simple_update_2site!(
 
     # truncate virtual index
     if any(!isnothing, (threshold, maxdim))
-        truncate!(ψ, [bond...]; threshold, maxdim)
-        renormalize && normalize!(ψ, bond[1])
+        truncate!(ψ, collect(bond); threshold, maxdim)
+        renormalize && normalize!(ψ, bond)
     end
 
     return ψ

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -328,7 +328,7 @@ end
 Truncate the dimension of the virtual `bond` of a [`Canonical`](@ref) Tensor Network by keeping the `maxdim` largest
 **Schmidt coefficients** or those larger than `threshold`, and then recanonizes the Tensor Network if `recanonize` is `true`.
 """
-function truncate!(::Canonical, tn::AbstractAnsatz, bond; threshold, maxdim, recanonize=false, renormalize=renormalize)
+function truncate!(::Canonical, tn::AbstractAnsatz, bond; threshold, maxdim, recanonize=true, renormalize=false)
     truncate!(NonCanonical(), tn, bond; threshold, maxdim, compute_local_svd=false, renormalize=renormalize)
 
     recanonize && canonize!(tn)

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -419,8 +419,11 @@ function simple_update_1site!(ψ::AbstractAnsatz, gate)
     return contract!(ψ, contracting_index)
 end
 
-simple_update_2site!(::MixedCanonical, ψ::AbstractAnsatz, gate; threshold=nothing, maxdim=nothing, renormalize=false) =
-    simple_update_2site!(NonCanonical(), ψ, gate; threshold, maxdim, renormalize)
+function simple_update_2site!(
+    ::MixedCanonical, ψ::AbstractAnsatz, gate; threshold=nothing, maxdim=nothing, renormalize=false
+)
+    return simple_update_2site!(NonCanonical(), ψ, gate; threshold, maxdim, renormalize)
+end
 
 # TODO remove `renormalize` argument?
 function simple_update_2site!(

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -324,7 +324,7 @@ Truncate the dimension of the virtual `bond` of a [`Canonical`](@ref) Tensor Net
 function truncate!(::Canonical, tn::AbstractAnsatz, bond; threshold, maxdim, recanonize=true)
     truncate!(NonCanonical(), tn, bond; threshold, maxdim, compute_local_svd=false)
 
-    recanonize && canonize!(tn)
+    recanonize && canonize!(tn; normalize=true)
 
     return tn
 end

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -560,7 +560,7 @@ end
 
 function LinearAlgebra.normalize!(config::Canonical, ψ::AbstractMPO; at=nothing)
     if isnothing(at) # Normalize all λ tensors
-        normalizer = (norm(ψ))^(1/(nsites(ψ)-1))
+        normalizer = (norm(ψ))^(1 / (nsites(ψ) - 1))
 
         for i in 1:(nsites(ψ) - 1)
             λ = tensors(ψ; between=(Site(i), Site(i + 1)))

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -481,7 +481,7 @@ function canonize_site!(ψ::MPS, site::Site; direction::Symbol, method=:qr)
     return ψ
 end
 
-function canonize!(ψ::AbstractMPO)
+function canonize!(ψ::AbstractMPO; normalize=false)
     Λ = Tensor[]
 
     # right-to-left QR sweep, get right-canonical tensors
@@ -495,6 +495,7 @@ function canonize!(ψ::AbstractMPO)
 
         # extract the singular values and contract them with the next tensor
         Λᵢ = pop!(ψ, tensors(ψ; between=(Site(i), Site(i + 1))))
+        normalize && (Λᵢ ./= norm(Λᵢ))
         Aᵢ₊₁ = tensors(ψ; at=Site(i + 1))
         replace!(ψ, Aᵢ₊₁ => contract(Aᵢ₊₁, Λᵢ; dims=()))
         push!(Λ, Λᵢ)
@@ -556,4 +557,4 @@ function LinearAlgebra.normalize!(config::MixedCanonical, ψ::AbstractMPO; at=co
     return ψ
 end
 
-# TODO function LinearAlgebra.normalize!(::Canonical, ψ::AbstractMPO) end
+LinearAlgebra.normalize!(::Canonical, ψ::AbstractMPO) = canonize!(ψ; normalize=true)

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -541,11 +541,11 @@ function mixed_canonize!(tn::AbstractMPO, orthog_center)
     return tn
 end
 
-LinearAlgebra.normalize(ψ::AbstractMPO, site) = normalize!(copy(ψ), site)
-
 LinearAlgebra.normalize!(ψ::AbstractMPO; kwargs...) = normalize!(form(ψ), ψ; kwargs...)
-LinearAlgebra.normalize!(ψ::AbstractMPO, site) = normalize!(form(ψ), ψ; at=site)
+LinearAlgebra.normalize!(ψ::AbstractMPO, at::Site) = normalize!(form(ψ), ψ; at)
+LinearAlgebra.normalize!(ψ::AbstractMPO, bond::Base.AbstractVecOrTuple{Site}) = normalize!(form(ψ), ψ; bond)
 
+# NOTE: Normalize in place should use less memory
 function LinearAlgebra.normalize!(::NonCanonical, ψ::AbstractMPO; at=Site(nsites(ψ) ÷ 2))
     if at isa Site
         tensor = tensors(ψ; at)
@@ -563,14 +563,14 @@ function LinearAlgebra.normalize!(config::MixedCanonical, ψ::AbstractMPO; at=co
     return ψ
 end
 
-function LinearAlgebra.normalize!(config::Canonical, ψ::AbstractMPO; at=nothing)
-    if isnothing(at) # Normalize all λ tensors
+function LinearAlgebra.normalize!(config::Canonical, ψ::AbstractMPO; bond=nothing)
+    if isnothing(bond) # Normalize all λ tensors
         for i in 1:(nsites(ψ) - 1)
             λ = tensors(ψ; between=(Site(i), Site(i + 1)))
             replace!(ψ, λ => λ ./ norm(λ)^(1 / (nsites(ψ) - 1)))
         end
     else
-        λ = tensors(ψ; between=at)
+        λ = tensors(ψ; between=bond)
         replace!(ψ, λ => λ ./ norm(λ))
     end
 

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -541,7 +541,11 @@ function mixed_canonize!(tn::AbstractMPO, orthog_center)
     return tn
 end
 
+LinearAlgebra.normalize(ψ::AbstractMPO; kwargs...) = normalize!(copy(ψ); kwargs...)
+LinearAlgebra.normalize(ψ::AbstractMPO, site::Site) = normalize!(copy(ψ), site)
+
 LinearAlgebra.normalize!(ψ::AbstractMPO; kwargs...) = normalize!(form(ψ), ψ; kwargs...)
+LinearAlgebra.normalize!(ψ::AbstractMPO, site::Site) = normalize!(form(ψ), ψ; at=site)
 
 function LinearAlgebra.normalize!(::NonCanonical, ψ::AbstractMPO; at=Site(nsites(ψ) ÷ 2))
     tensor = tensors(ψ; at)
@@ -549,7 +553,7 @@ function LinearAlgebra.normalize!(::NonCanonical, ψ::AbstractMPO; at=Site(nsite
     return ψ
 end
 
-LinearAlgebra.normalize!(ψ::AbstractMPO, site::Site) = normalize!(mixed_canonize!(ψ, site); at=site)
+LinearAlgebra.normalize!(config::NonCanonical, ψ::AbstractMPO; at=site) = normalize!(MixedCanonical(at), ψ; at)
 
 function LinearAlgebra.normalize!(config::MixedCanonical, ψ::AbstractMPO; at=config.orthog_center)
     mixed_canonize!(ψ, at)
@@ -557,4 +561,9 @@ function LinearAlgebra.normalize!(config::MixedCanonical, ψ::AbstractMPO; at=co
     return ψ
 end
 
-LinearAlgebra.normalize!(::Canonical, ψ::AbstractMPO) = canonize!(ψ; normalize=true)
+function LinearAlgebra.normalize!(config::Canonical, ψ::AbstractMPO; at=Site(nsites(ψ) ÷ 2))
+    λ = tensors(ψ; between=(at, Site(id(at) + 1)))
+    replace!(ψ, λ => λ ./ norm(ψ))
+
+    return ψ
+end

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -558,9 +558,16 @@ function LinearAlgebra.normalize!(config::MixedCanonical, ψ::AbstractMPO; at=co
     return ψ
 end
 
-function LinearAlgebra.normalize!(config::Canonical, ψ::AbstractMPO; at=(Site(nsites(ψ) ÷ 2), Site(nsites(ψ) ÷ 2 + 1)))
-    λ = tensors(ψ; between=at)
-    replace!(ψ, λ => λ ./ norm(ψ))
+function LinearAlgebra.normalize!(config::Canonical, ψ::AbstractMPO; at=nothing)
+    if isnothing(at) # Normalize all λ tensors
+        for i in 1:nsites(ψ)-1
+            λ = tensors(ψ; between=(Site(i), Site(i + 1)))
+            replace!(ψ, λ => λ ./ norm(ψ))
+        end
+    else
+        λ = tensors(ψ; between=at)
+        replace!(ψ, λ => λ ./ norm(ψ))
+    end
 
     return ψ
 end

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -560,9 +560,11 @@ end
 
 function LinearAlgebra.normalize!(config::Canonical, ψ::AbstractMPO; at=nothing)
     if isnothing(at) # Normalize all λ tensors
+        normalizer = (norm(ψ))^(1/(nsites(ψ)-1))
+
         for i in 1:(nsites(ψ) - 1)
             λ = tensors(ψ; between=(Site(i), Site(i + 1)))
-            replace!(ψ, λ => λ ./ norm(ψ))
+            replace!(ψ, λ => λ ./ normalizer)
         end
     else
         λ = tensors(ψ; between=at)

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -545,7 +545,7 @@ LinearAlgebra.normalize!(ψ::AbstractMPO; kwargs...) = normalize!(form(ψ), ψ; 
 LinearAlgebra.normalize!(ψ::AbstractMPO, at::Site) = normalize!(form(ψ), ψ; at)
 LinearAlgebra.normalize!(ψ::AbstractMPO, bond::Base.AbstractVecOrTuple{Site}) = normalize!(form(ψ), ψ; bond)
 
-# NOTE: Normalize in place should use less memory
+# NOTE: Inplace normalization of the arrays should be faster, but currently lead to problems for `copy` TensorNetworks
 function LinearAlgebra.normalize!(::NonCanonical, ψ::AbstractMPO; at=Site(nsites(ψ) ÷ 2))
     if at isa Site
         tensor = tensors(ψ; at)

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -549,7 +549,7 @@ LinearAlgebra.normalize!(ψ::AbstractMPO, site) = normalize!(form(ψ), ψ; at=si
 function LinearAlgebra.normalize!(::NonCanonical, ψ::AbstractMPO; at=Site(nsites(ψ) ÷ 2))
     if at isa Site
         tensor = tensors(ψ; at)
-        tensor ./= norm(ψ)
+        replace!(ψ, tensor => tensor ./ norm(ψ))
     else
         normalize!(mixed_canonize!(ψ, at))
     end

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -560,7 +560,7 @@ end
 
 function LinearAlgebra.normalize!(config::Canonical, ψ::AbstractMPO; at=nothing)
     if isnothing(at) # Normalize all λ tensors
-        for i in 1:nsites(ψ)-1
+        for i in 1:(nsites(ψ) - 1)
             λ = tensors(ψ; between=(Site(i), Site(i + 1)))
             replace!(ψ, λ => λ ./ norm(ψ))
         end

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -541,11 +541,10 @@ function mixed_canonize!(tn::AbstractMPO, orthog_center)
     return tn
 end
 
-LinearAlgebra.normalize(ψ::AbstractMPO; kwargs...) = normalize!(copy(ψ); kwargs...)
-LinearAlgebra.normalize(ψ::AbstractMPO, site::Site) = normalize!(copy(ψ), site)
+LinearAlgebra.normalize(ψ::AbstractMPO, site) = normalize!(copy(ψ), site)
 
 LinearAlgebra.normalize!(ψ::AbstractMPO; kwargs...) = normalize!(form(ψ), ψ; kwargs...)
-LinearAlgebra.normalize!(ψ::AbstractMPO, site::Site) = normalize!(form(ψ), ψ; at=site)
+LinearAlgebra.normalize!(ψ::AbstractMPO, site) = normalize!(form(ψ), ψ; at=site)
 
 function LinearAlgebra.normalize!(::NonCanonical, ψ::AbstractMPO; at=Site(nsites(ψ) ÷ 2))
     tensor = tensors(ψ; at)
@@ -553,16 +552,14 @@ function LinearAlgebra.normalize!(::NonCanonical, ψ::AbstractMPO; at=Site(nsite
     return ψ
 end
 
-LinearAlgebra.normalize!(config::NonCanonical, ψ::AbstractMPO; at=site) = normalize!(MixedCanonical(at), ψ; at)
-
 function LinearAlgebra.normalize!(config::MixedCanonical, ψ::AbstractMPO; at=config.orthog_center)
     mixed_canonize!(ψ, at)
     normalize!(tensors(ψ; at), 2)
     return ψ
 end
 
-function LinearAlgebra.normalize!(config::Canonical, ψ::AbstractMPO; at=Site(nsites(ψ) ÷ 2))
-    λ = tensors(ψ; between=(at, Site(id(at) + 1)))
+function LinearAlgebra.normalize!(config::Canonical, ψ::AbstractMPO; at=(Site(nsites(ψ) ÷ 2), Site(nsites(ψ) ÷ 2 + 1)))
+    λ = tensors(ψ; between=at)
     replace!(ψ, λ => λ ./ norm(ψ))
 
     return ψ

--- a/src/Quantum.jl
+++ b/src/Quantum.jl
@@ -408,6 +408,8 @@ function Base.merge!(a::AbstractQuantum, b::AbstractQuantum; reset=true)
     return a
 end
 
+LinearAlgebra.normalize(ψ::AbstractQuantum; kwargs...) = normalize!(copy(ψ); kwargs...)
+
 function LinearAlgebra.norm(ψ::AbstractQuantum, p::Real=2; kwargs...)
     p == 2 || throw(ArgumentError("only L2-norm is implemented yet"))
     return LinearAlgebra.norm2(ψ; kwargs...)

--- a/test/MPS_test.jl
+++ b/test/MPS_test.jl
@@ -308,13 +308,12 @@ using LinearAlgebra
             @testset "Canonical" begin
                 ψ = rand(MPS; n=5, maxdim=20)
                 ϕ = deepcopy(ψ)
-                ϕ.form = NonCanonical()
-                canonize!(ψ; normalize=false)
-                evolved = evolve!(deepcopy(ψ), gate; threshold=1e-24)
+                canonize!(ψ)
+                evolved = evolve!(deepcopy(ψ), gate)
 
-                @test isapprox(contract(evolved), contract(ϕ))
-                # @test issetequal(size.(tensors(evolved)), [(2, 2), (2,), (2, 2, 2), (2,), (2, 2, 2), (2,), (2, 2)])
+                @test isapprox(contract(evolved), contract(ϕ)) # Identity gate should not change the state
 
+                # Ensure that the original MixedCanonical state evolves into the same state as the canonicalized one
                 @test contract(evolve!(ϕ, gate; threshold=1e-14)) ≈ contract(ψ)
             end
         end

--- a/test/MPS_test.jl
+++ b/test/MPS_test.jl
@@ -147,9 +147,36 @@ using LinearAlgebra
     @testset "normalize!" begin
         using LinearAlgebra: normalize!
 
-        ψ = MPS([rand(4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4)])
-        normalize!(ψ, Site(3))
-        @test isapprox(norm(ψ), 1.0)
+        @testset "NonCanonical" begin
+            ψ = MPS([rand(4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4)])
+
+            normalized = normalize(ψ)
+            @test norm(normalized) ≈ 1.0
+
+            normalize!(ψ, Site(3))
+            @test norm(ψ) ≈ 1.0
+        end
+
+        @testset "MixedCanonical" begin
+            ψ = rand(MPS; n=5, maxdim=16)
+
+            normalized = normalize(ψ)
+            @test norm(normalized) ≈ 1.0
+
+            normalize!(ψ, Site(3))
+            @test norm(ψ) ≈ 1.0
+        end
+
+        @testset "Canonical" begin
+            ψ = rand(MPS; n=5, maxdim=16)
+            canonize!(ψ)
+
+            normalized = normalize(ψ)
+            @test norm(normalized) ≈ 1.0
+
+            normalize!(ψ, Site(3))
+            @test norm(ψ) ≈ 1.0
+        end
     end
 
     @testset "canonize_site!" begin

--- a/test/MPS_test.jl
+++ b/test/MPS_test.jl
@@ -109,15 +109,10 @@ using LinearAlgebra
             # If maxdim > size(spectrum), the bond dimension is not truncated
             truncated = truncate(ψ, [site"2", site"3"]; maxdim=4)
             @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 2
-        end
 
-        @testset "Canonical" begin
-            ψ = rand(MPS; n=5, maxdim=16)
-            canonize!(ψ)
-
-            truncated = truncate(ψ, [site"2", site"3"]; maxdim=2, recanonize=true)
-            @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 2
-            @test Tenet.check_form(truncated)
+            normalize!(ψ)
+            truncated = truncate(ψ, [site"2", site"3"]; maxdim=1, renormalize=true)
+            @test norm(truncated) ≈ 1.0
         end
 
         @testset "MixedCanonical" begin
@@ -125,6 +120,22 @@ using LinearAlgebra
 
             truncated = truncate(ψ, [site"2", site"3"]; maxdim=3)
             @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 3
+
+            truncated = truncate(ψ, [site"2", site"3"]; maxdim=3, renormalize=true)
+            @test norm(truncated) ≈ 1.0
+        end
+
+        @testset "Canonical" begin
+            ψ = rand(MPS; n=5, maxdim=16)
+            canonize!(ψ)
+
+            truncated = truncate(ψ, [site"2", site"3"]; maxdim=2, recanonize=true, renormalize=true)
+            @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 2
+            @test Tenet.check_form(truncated)
+            @test norm(truncated) ≈ 1.0
+
+            truncated = truncate(ψ, [site"2", site"3"]; maxdim=2, recanonize=false, renormalize=true)
+            @test norm(truncated) ≈ 1.0
         end
     end
 

--- a/test/MPS_test.jl
+++ b/test/MPS_test.jl
@@ -145,7 +145,7 @@ using LinearAlgebra
     end
 
     @testset "normalize!" begin
-        using LinearAlgebra: normalize!
+        using LinearAlgebra: normalize, normalize!
 
         @testset "NonCanonical" begin
             ψ = MPS([rand(4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4)])
@@ -160,6 +160,10 @@ using LinearAlgebra
         @testset "MixedCanonical" begin
             ψ = rand(MPS; n=5, maxdim=16)
 
+            # Perturb the state to make it non-normalized
+            t = tensors(ψ; at=site"3")
+            replace!(ψ, t => Tensor(rand(size(t)...), inds(t)))
+
             normalized = normalize(ψ)
             @test norm(normalized) ≈ 1.0
 
@@ -168,13 +172,13 @@ using LinearAlgebra
         end
 
         @testset "Canonical" begin
-            ψ = rand(MPS; n=5, maxdim=16)
+            ψ = MPS([rand(4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4)])
             canonize!(ψ)
 
             normalized = normalize(ψ)
             @test norm(normalized) ≈ 1.0
 
-            normalize!(ψ, Site(3))
+            normalize!(ψ, (Site(3), Site(4)))
             @test norm(ψ) ≈ 1.0
         end
     end

--- a/test/MPS_test.jl
+++ b/test/MPS_test.jl
@@ -115,8 +115,9 @@ using LinearAlgebra
             ψ = rand(MPS; n=5, maxdim=16)
             canonize!(ψ)
 
-            truncated = truncate(ψ, [site"2", site"3"]; maxdim=2)
+            truncated = truncate(ψ, [site"2", site"3"]; maxdim=2, recanonize=true)
             @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 2
+            @test Tenet.check_form(truncated)
         end
 
         @testset "MixedCanonical" begin
@@ -311,6 +312,7 @@ using LinearAlgebra
                 canonize!(ψ)
                 evolved = evolve!(deepcopy(ψ), gate)
 
+                @test Tenet.check_form(evolved)
                 @test isapprox(contract(evolved), contract(ϕ)) # Identity gate should not change the state
 
                 # Ensure that the original MixedCanonical state evolves into the same state as the canonicalized one

--- a/test/MPS_test.jl
+++ b/test/MPS_test.jl
@@ -306,11 +306,16 @@ using LinearAlgebra
             end
 
             @testset "Canonical" begin
-                ψ = deepcopy(ψ)
-                canonize!(ψ)
-                evolved = evolve!(deepcopy(ψ), gate; threshold=1e-14)
-                @test isapprox(contract(evolved), contract(ψ))
-                @test issetequal(size.(tensors(evolved)), [(2, 2), (2,), (2, 2, 2), (2,), (2, 2, 2), (2,), (2, 2)])
+                ψ = rand(MPS; n=5, maxdim=20)
+                ϕ = deepcopy(ψ)
+                ϕ.form = NonCanonical()
+                canonize!(ψ; normalize=false)
+                evolved = evolve!(deepcopy(ψ), gate; threshold=1e-24)
+
+                @test isapprox(contract(evolved), contract(ϕ))
+                # @test issetequal(size.(tensors(evolved)), [(2, 2), (2,), (2, 2, 2), (2,), (2, 2, 2), (2,), (2, 2)])
+
+                @test contract(evolve!(ϕ, gate; threshold=1e-14)) ≈ contract(ψ)
             end
         end
     end

--- a/test/MPS_test.jl
+++ b/test/MPS_test.jl
@@ -111,7 +111,7 @@ using LinearAlgebra
             @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 2
 
             normalize!(ψ)
-            truncated = truncate(ψ, [site"2", site"3"]; maxdim=1, renormalize=true)
+            truncated = truncate(ψ, [site"2", site"3"]; maxdim=1, normalize=true)
             @test norm(truncated) ≈ 1.0
         end
 
@@ -121,7 +121,7 @@ using LinearAlgebra
             truncated = truncate(ψ, [site"2", site"3"]; maxdim=3)
             @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 3
 
-            truncated = truncate(ψ, [site"2", site"3"]; maxdim=3, renormalize=true)
+            truncated = truncate(ψ, [site"2", site"3"]; maxdim=3, normalize=true)
             @test norm(truncated) ≈ 1.0
         end
 
@@ -129,12 +129,12 @@ using LinearAlgebra
             ψ = rand(MPS; n=5, maxdim=16)
             canonize!(ψ)
 
-            truncated = truncate(ψ, [site"2", site"3"]; maxdim=2, recanonize=true, renormalize=true)
+            truncated = truncate(ψ, [site"2", site"3"]; maxdim=2, canonize=true, normalize=true)
             @test size(truncated, inds(truncated; bond=[site"2", site"3"])) == 2
             @test Tenet.check_form(truncated)
             @test norm(truncated) ≈ 1.0
 
-            truncated = truncate(ψ, [site"2", site"3"]; maxdim=2, recanonize=false, renormalize=true)
+            truncated = truncate(ψ, [site"2", site"3"]; maxdim=2, canonize=false, normalize=true)
             @test norm(truncated) ≈ 1.0
         end
     end
@@ -347,7 +347,7 @@ using LinearAlgebra
                 @test issetequal(size.(tensors(ϕ)), [(2, 2), (2, 2, 2), (2,), (2, 2, 2), (2, 2, 2), (2, 2)])
                 @test isapprox(contract(ϕ), contract(ψ))
 
-                evolved = evolve!(normalize(ψ), gate; maxdim=1, renormalize=true)
+                evolved = evolve!(normalize(ψ), gate; maxdim=1, normalize=true)
                 @test norm(evolved) ≈ 1.0
             end
 
@@ -365,11 +365,11 @@ using LinearAlgebra
                 # Ensure that the original MixedCanonical state evolves into the same state as the canonicalized one
                 @test contract(ψ) ≈ contract(evolve!(ϕ, gate; threshold=1e-14))
 
-                evolved = evolve!(deepcopy(ψ), gate; maxdim=1, renormalize=true, recanonize=true)
+                evolved = evolve!(deepcopy(ψ), gate; maxdim=1, normalize=true, canonize=true)
                 @test norm(evolved) ≈ 1.0
                 @test Tenet.check_form(evolved)
 
-                evolved = evolve!(deepcopy(ψ), gate; maxdim=1, renormalize=true, recanonize=false)
+                evolved = evolve!(deepcopy(ψ), gate; maxdim=1, normalize=true, canonize=false)
                 @test norm(evolved) ≈ 1.0
                 @test_throws ArgumentError Tenet.check_form(evolved)
             end


### PR DESCRIPTION
### Summary
This PR refactors the `simple_update!` function so now it properly uses the $\Lambda$ tensors of an `MPS` in the `Canonical` form to `evolve` the state without the need of recanonizing it.

Additionally, we also added the `kwarg` of `normalize` in the `canonize!` function.

