### PR TITLE
Add `evolve!` for evolution of an `MPS` with an `MPO`

### DIFF
--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -338,7 +338,7 @@ end
 Truncate the dimension of the virtual `bond` of a [`Canonical`](@ref) Tensor Network by keeping the `maxdim` largest
 **Schmidt coefficients** or those larger than `threshold`, and then canonizes the Tensor Network if `canonize` is `true`.
 """
-function truncate!(::Canonical, tn::AbstractAnsatz, bond; canonize = true, kwargs...)
+function truncate!(::Canonical, tn::AbstractAnsatz, bond; canonize=true, kwargs...)
     truncate!(NonCanonical(), tn, bond; compute_local_svd=false, kwargs...)
 
     canonize && canonize!(tn)

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -325,21 +325,21 @@ function truncate!(::NonCanonical, tn::AbstractAnsatz, bond; threshold, maxdim, 
     return tn
 end
 
-function truncate!(::MixedCanonical, tn::AbstractAnsatz, bond; threshold, maxdim, normalize=false)
+function truncate!(::MixedCanonical, tn::AbstractAnsatz, bond; kwargs...)
     # move orthogonality center to bond
     mixed_canonize!(tn, bond)
 
-    return truncate!(NonCanonical(), tn, bond; threshold, maxdim, compute_local_svd=true, normalize)
+    return truncate!(NonCanonical(), tn, bond; compute_local_svd=true, kwargs...)
 end
 
 """
-    truncate!(::Canonical, tn::AbstractAnsatz, bond; threshold, maxdim, canonize=true)
+    truncate!(::Canonical, tn::AbstractAnsatz, bond; canonize=true, kwargs...)
 
 Truncate the dimension of the virtual `bond` of a [`Canonical`](@ref) Tensor Network by keeping the `maxdim` largest
 **Schmidt coefficients** or those larger than `threshold`, and then canonizes the Tensor Network if `canonize` is `true`.
 """
-function truncate!(::Canonical, tn::AbstractAnsatz, bond; threshold, maxdim, canonize=false, normalize=false)
-    truncate!(NonCanonical(), tn, bond; threshold, maxdim, compute_local_svd=false, normalize)
+function truncate!(::Canonical, tn::AbstractAnsatz, bond; canonize = true, kwargs...)
+    truncate!(NonCanonical(), tn, bond; compute_local_svd=false, kwargs...)
 
     canonize && canonize!(tn)
 

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -326,7 +326,8 @@ function truncate!(::NonCanonical, tn::AbstractAnsatz, bond; threshold, maxdim, 
 end
 
 function truncate!(::MixedCanonical, tn::AbstractAnsatz, bond; kwargs...)
-    mixed_canonize!(tn, bond) # move orthogonality center to bond
+    # move orthogonality center to bond
+    mixed_canonize!(tn, bond)
 
     return truncate!(NonCanonical(), tn, bond; compute_local_svd=true, kwargs...)
 end

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -326,8 +326,7 @@ function truncate!(::NonCanonical, tn::AbstractAnsatz, bond; threshold, maxdim, 
 end
 
 function truncate!(::MixedCanonical, tn::AbstractAnsatz, bond; kwargs...)
-    # move orthogonality center to bond
-    mixed_canonize!(tn, bond)
+    mixed_canonize!(tn, bond) # move orthogonality center to bond
 
     return truncate!(NonCanonical(), tn, bond; compute_local_svd=true, kwargs...)
 end

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -543,13 +543,23 @@ function mixed_canonize!(tn::AbstractMPO, orthog_center)
 end
 
 """
-    evolve!(ψ::AbstractAnsatz, mpo::AbstractMPO; threshold=nothing, maxdim=nothing, normalize=true)
+    evolve!(ψ::AbstractAnsatz, mpo::AbstractMPO; threshold=nothing, maxdim=nothing, normalize=true, reset_index=true)
 
 Evolve the [`AbstractAnsatz`](@ref) `ψ` with the [`AbstractMPO`](@ref) `mpo` along the output indices of `ψ`.
-If `threshold` or `maxdim` are not `nothing`, the tensors are truncated after each sweep at the proper value.
+If `threshold` or `maxdim` are not `nothing`, the tensors are truncated after each sweep at the proper value, and the
+bond is normalized if `normalize=true`. If `reset_index=true`, the indices of the `ψ` are reset to the original ones.
 """
-function evolve!(ψ::AbstractAnsatz, mpo::AbstractMPO; threshold=nothing, maxdim=nothing, normalize=true)
+function evolve!(ψ::AbstractAnsatz, mpo::AbstractMPO; threshold=nothing, maxdim=nothing, normalize=true, reset_index=true)
+    original_sites = copy(Quantum(ψ).sites)
     evolve!(form(ψ), ψ, mpo; threshold, maxdim, normalize)
+
+    if reset_index
+        resetindex!(Quantum(ψ); init=ninds(TensorNetwork(ψ))+1)
+
+        replacements = [(Quantum(ψ).sites[key] => original_sites[key]) for key in keys(original_sites)]
+        replace!(Quantum(ψ), replacements)
+    end
+
     return ψ
 end
 

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -563,7 +563,7 @@ function evolve!(ψ::AbstractAnsatz, mpo::AbstractMPO; threshold=nothing, maxdim
     end
 
     if form(ψ) isa Canonical
-        canonize!(ψ; normalize=normalize)
+        canonize!(ψ; normalize=normalize) # TODO: check how do we lose canonicity if we do not canonize
     elseif form(ψ) isa MixedCanonical
         mixed_canonize!(ψ, form(ψ).orthog_center)
         normalize && normalize!(ψ)

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -621,7 +621,7 @@ function evolve!(::Canonical, ψ::AbstractAnsatz, mpo::AbstractMPO; threshold, m
 end
 
 """
-	truncate_sweep!
+    truncate_sweep!
 
 Do a right-to-left QR sweep on the [`AbstractMPO`](@ref) `ψ` and then left-to-right SVD sweep and truncate the tensors
 according to the `threshold` or `maxdim` values. The bond is normalized if `normalize=true`.

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -544,8 +544,6 @@ end
 function evolve!(ψ::AbstractAnsatz, mpo::AbstractMPO; threshold=nothing, maxdim=nothing, normalize=true)
     evolve!(form(ψ), ψ, mpo; threshold, maxdim, normalize)
 
-    @show form(ψ)
-
     if !isnothing(threshold) || !isnothing(maxdim) || form(ψ) isa MixedCanonical
         # right-to-left QR sweep, get right-canonical tensors
         for i in nsites(ψ):-1:2

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -549,12 +549,14 @@ Evolve the [`AbstractAnsatz`](@ref) `ψ` with the [`AbstractMPO`](@ref) `mpo` al
 If `threshold` or `maxdim` are not `nothing`, the tensors are truncated after each sweep at the proper value, and the
 bond is normalized if `normalize=true`. If `reset_index=true`, the indices of the `ψ` are reset to the original ones.
 """
-function evolve!(ψ::AbstractAnsatz, mpo::AbstractMPO; threshold=nothing, maxdim=nothing, normalize=true, reset_index=true)
+function evolve!(
+    ψ::AbstractAnsatz, mpo::AbstractMPO; threshold=nothing, maxdim=nothing, normalize=true, reset_index=true
+)
     original_sites = copy(Quantum(ψ).sites)
     evolve!(form(ψ), ψ, mpo; threshold, maxdim, normalize)
 
     if reset_index
-        resetindex!(Quantum(ψ); init=ninds(TensorNetwork(ψ))+1)
+        resetindex!(Quantum(ψ); init=ninds(TensorNetwork(ψ)) + 1)
 
         replacements = [(Quantum(ψ).sites[key] => original_sites[key]) for key in keys(original_sites)]
         replace!(Quantum(ψ), replacements)

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -664,8 +664,6 @@ function truncate_sweep!(::Canonical, ψ::AbstractMPO; threshold, maxdim, normal
             truncate!(ψ, [Site(i), Site(i + 1)]; threshold, maxdim, normalize, compute_local_svd=false)
     end
 
-    show_lambda(ψ) = [tensors(ψ; between=(Site(i), Site(i + 1))) for i in 1:(nsites(ψ) - 1)]
-
     canonize!(ψ)
 
     return ψ

--- a/test/MPS_test.jl
+++ b/test/MPS_test.jl
@@ -387,6 +387,9 @@ using LinearAlgebra
             @testset "NonCanonical" begin
                 evolve!(ϕ_1, mpo)
                 @test length(tensors(ϕ_1)) == 5
+
+                evolved = evolve!(deepcopy(ψ), mpo; maxdim = 3)
+                @test all(x -> x ≤ 3, vcat([collect(t) for t in vec(size.(tensors(evolved)))]...))
             end
 
             @testset "Canonical" begin
@@ -395,6 +398,11 @@ using LinearAlgebra
                 @test length(tensors(ϕ_2)) == 5 + 4
                 @test form(ϕ_2) == Canonical()
                 @test Tenet.check_form(ϕ_2)
+
+                evolved = evolve!(deepcopy(canonize!(ψ)), mpo; maxdim = 3, normalize=true)
+                @test all(x -> x ≤ 3, vcat([collect(t) for t in vec(size.(tensors(evolved)))]...))
+                @test form(evolved) == Canonical()
+                @test Tenet.check_form(evolved)
             end
 
             @testset "MixedCanonical" begin
@@ -403,6 +411,11 @@ using LinearAlgebra
                 @test length(tensors(ϕ_3)) == 5
                 @test form(ϕ_3) == MixedCanonical(Site(3))
                 @test Tenet.check_form(ϕ_3)
+
+                evolved = evolve!(deepcopy(mixed_canonize!(ψ, site"3")), mpo; maxdim = 3)
+                @test all(x -> x ≤ 3, vcat([collect(t) for t in vec(size.(tensors(evolved)))]...))
+                @test form(evolved) == MixedCanonical(Site(3))
+                @test Tenet.check_form(evolved)
             end
 
             function create_replacements(ϕ_1_sites::Dict, ϕ_2_sites::Dict)

--- a/test/MPS_test.jl
+++ b/test/MPS_test.jl
@@ -399,7 +399,7 @@ using LinearAlgebra
                 @test form(ϕ_2) == Canonical()
                 @test Tenet.check_form(ϕ_2)
 
-                evolved = evolve!(deepcopy(canonize!(ψ)), mpo; maxdim=3, normalize=true)
+                evolved = evolve!(deepcopy(canonize!(ψ)), mpo; maxdim=3)
                 @test all(x -> x ≤ 3, vcat([collect(t) for t in vec(size.(tensors(evolved)))]...))
                 @test form(evolved) == Canonical()
                 @test Tenet.check_form(evolved)

--- a/test/MPS_test.jl
+++ b/test/MPS_test.jl
@@ -422,21 +422,9 @@ using LinearAlgebra
                 @test Tenet.check_form(evolved)
             end
 
-            function create_replacements(ϕ_1_sites::Dict, ϕ_2_sites::Dict)
-                # Ensure the keys match in both dictionaries
-                if keys(ϕ_1_sites) != keys(ϕ_2_sites)
-                    throw(ArgumentError("Keys of the dictionaries do not match."))
-                end
-
-                # Create a list of replacements
-                replacements = [(ϕ_2_sites[key] => ϕ_1_sites[key]) for key in keys(ϕ_1_sites)]
-
-                return replacements
-            end
-
             t1 = contract(ϕ_1)
-            t2 = replace(contract(ϕ_2), create_replacements(Quantum(ϕ_1).sites, Quantum(ϕ_2).sites)...)
-            t3 = replace(contract(ϕ_3), create_replacements(Quantum(ϕ_1).sites, Quantum(ϕ_3).sites)...)
+            t2 = contract(ϕ_2)
+            t3 = contract(ϕ_3)
 
             @test t1 ≈ t2 ≈ t3
             @test only(overlap(ϕ_1, ϕ_2)) ≈ only(overlap(ϕ_1, ϕ_3)) ≈ only(overlap(ϕ_2, ϕ_3)) ≈ 1.0

--- a/test/MPS_test.jl
+++ b/test/MPS_test.jl
@@ -378,7 +378,7 @@ using LinearAlgebra
         @testset "MPO evolution" begin
             ψ = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2, 2), rand(2, 2, 2), rand(2, 2)])
             normalize!(ψ)
-            mpo = rand(MPO; n=5, maxdim=4)
+            mpo = rand(MPO; n=5, maxdim=8)
 
             ϕ_1 = deepcopy(ψ)
             ϕ_2 = deepcopy(ψ)
@@ -387,9 +387,11 @@ using LinearAlgebra
             @testset "NonCanonical" begin
                 evolve!(ϕ_1, mpo)
                 @test length(tensors(ϕ_1)) == 5
+                @test norm(ϕ_1) ≈ 1.0
 
                 evolved = evolve!(deepcopy(ψ), mpo; maxdim=3)
                 @test all(x -> x ≤ 3, vcat([collect(t) for t in vec(size.(tensors(evolved)))]...))
+                @test norm(evolved) ≈ 1.0
             end
 
             @testset "Canonical" begin
@@ -410,11 +412,13 @@ using LinearAlgebra
                 evolve!(ϕ_3, mpo)
                 @test length(tensors(ϕ_3)) == 5
                 @test form(ϕ_3) == MixedCanonical(Site(3))
+                @test norm(ϕ_3) ≈ 1.0
                 @test Tenet.check_form(ϕ_3)
 
                 evolved = evolve!(deepcopy(mixed_canonize!(ψ, site"3")), mpo; maxdim=3)
                 @test all(x -> x ≤ 3, vcat([collect(t) for t in vec(size.(tensors(evolved)))]...))
                 @test form(evolved) == MixedCanonical(Site(3))
+                @test norm(evolved) ≈ 1.0
                 @test Tenet.check_form(evolved)
             end
 
@@ -435,6 +439,7 @@ using LinearAlgebra
             t3 = replace(contract(ϕ_3), create_replacements(Quantum(ϕ_1).sites, Quantum(ϕ_3).sites)...)
 
             @test t1 ≈ t2 ≈ t3
+            @test only(overlap(ϕ_1, ϕ_2)) ≈ only(overlap(ϕ_1, ϕ_3)) ≈ only(overlap(ϕ_2, ϕ_3)) ≈ 1.0
         end
     end
 

--- a/test/MPS_test.jl
+++ b/test/MPS_test.jl
@@ -388,7 +388,7 @@ using LinearAlgebra
                 evolve!(ϕ_1, mpo)
                 @test length(tensors(ϕ_1)) == 5
 
-                evolved = evolve!(deepcopy(ψ), mpo; maxdim = 3)
+                evolved = evolve!(deepcopy(ψ), mpo; maxdim=3)
                 @test all(x -> x ≤ 3, vcat([collect(t) for t in vec(size.(tensors(evolved)))]...))
             end
 
@@ -399,7 +399,7 @@ using LinearAlgebra
                 @test form(ϕ_2) == Canonical()
                 @test Tenet.check_form(ϕ_2)
 
-                evolved = evolve!(deepcopy(canonize!(ψ)), mpo; maxdim = 3, normalize=true)
+                evolved = evolve!(deepcopy(canonize!(ψ)), mpo; maxdim=3, normalize=true)
                 @test all(x -> x ≤ 3, vcat([collect(t) for t in vec(size.(tensors(evolved)))]...))
                 @test form(evolved) == Canonical()
                 @test Tenet.check_form(evolved)
@@ -412,7 +412,7 @@ using LinearAlgebra
                 @test form(ϕ_3) == MixedCanonical(Site(3))
                 @test Tenet.check_form(ϕ_3)
 
-                evolved = evolve!(deepcopy(mixed_canonize!(ψ, site"3")), mpo; maxdim = 3)
+                evolved = evolve!(deepcopy(mixed_canonize!(ψ, site"3")), mpo; maxdim=3)
                 @test all(x -> x ≤ 3, vcat([collect(t) for t in vec(size.(tensors(evolved)))]...))
                 @test form(evolved) == MixedCanonical(Site(3))
                 @test Tenet.check_form(evolved)


### PR DESCRIPTION
### Summary
This PR enhances the `evolve!` to handle the evolution of an `MPS` with an `MPO` in different canonical forms. Additionally, it includes new test cases to verify the correctness of the evolution functions.

- [x] Maybe fix code so the output indices are always like the input `mps`. This way things are easier to check if works properly.
- [x] Refactor and regroup some code so new canonical `Form`s do not need to change the `evolve!` funciton, but just extend it as they need.
- [x] Add more tests for variable `maxdim`, `threshold`? I don't know.

@starsfordummies Please take a look and tell me what do you think!

Also we should take a look at issue #238 (which asks to extend `mixed_canonize!` so it dispatches on `Form`). So if we already have an `mps` that is in `MixedCanonical`, there is no need to do the full sweep if we just want to change the ortogonality center.

### Example
```julia
julia> using Tenet; using Test

julia> ψ = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2, 2), rand(2, 2, 2), rand(2, 2)]); normalize!(ψ)
MPS (inputs=0, outputs=5)

julia> mpo = rand(MPO; n=5, maxdim=4)
MPO (inputs=5, outputs=5)

julia> ϕ_1 = evolve!(canonize(ψ), mpo)
MPS (inputs=0, outputs=5)

julia> ϕ_2 = evolve!(mixed_canonize!(ψ, Site(3)), mpo)
MPS (inputs=0, outputs=5)

julia> size.(ϕ_1)
9-element Vector{Tuple{Int64, Vararg{Int64}}}:
 (2,)
 (2, 2, 4)
 (2, 2)
 (2,)
 (4, 2, 2)
 (2, 2)
 (4,)
 (4, 2, 4)
 (4,)

julia> function create_replacements(ϕ_1_sites::Dict, ϕ_2_sites::Dict) # Function to reindex the output tensor
           # Ensure the keys match in both dictionaries
           if keys(ϕ_1_sites) != keys(ϕ_2_sites)
               throw(ArgumentError("Keys of the dictionaries do not match."))
           end

           # Create a list of replacements
           replacements = [(ϕ_2_sites[key] => ϕ_1_sites[key]) for key in keys(ϕ_1_sites)]

           return replacements
       end
create_replacements (generic function with 1 method)

julia> t1 = contract(ϕ_1)
2×2×2×2×2 Tensor{Float64, 5, Array{Float64, 5}}: ...

julia> t2 = replace(contract(ϕ_2), create_replacements(Quantum(ϕ_1).sites, Quantum(ϕ_2).sites)...)
2×2×2×2×2 Tensor{Float64, 5, Array{Float64, 5}}: ...

julia> @test t1 ≈ t2
Test Passed
```