### PR TITLE
Add missing `kwargs...` in `evolve`-related functions

### DIFF
--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -437,13 +437,13 @@ function simple_update_1site!(ψ::AbstractAnsatz, gate)
 end
 
 function simple_update_2site!(
-    ::MixedCanonical, ψ::AbstractAnsatz, gate; threshold=nothing, maxdim=nothing, normalize=false, kwargs...
+    ::MixedCanonical, ψ::AbstractAnsatz, gate; kwargs...
 )
-    return simple_update_2site!(NonCanonical(), ψ, gate; threshold, maxdim, normalize, kwargs...)
+    return simple_update_2site!(NonCanonical(), ψ, gate; kwargs...)
 end
 
 function simple_update_2site!(
-    ::NonCanonical, ψ::AbstractAnsatz, gate; threshold=nothing, maxdim=nothing, normalize=false, kwargs...
+    ::NonCanonical, ψ::AbstractAnsatz, gate; kwargs...
 )
     @assert has_edge(ψ, lanes(gate)...) "Gate must act on neighboring sites"
 
@@ -477,8 +477,8 @@ function simple_update_2site!(
     svd!(ψ; left_inds=linds, right_inds=rinds, virtualind=vind)
 
     # truncate virtual index
-    if any(!isnothing, (threshold, maxdim))
-        truncate!(ψ, collect(bond); threshold, maxdim, normalize, kwargs...)
+    if any(!isnothing, get.(Ref(kwargs), [:threshold, :maxdim], nothing))
+        truncate!(ψ, collect(bond); kwargs...)
     end
 
     return ψ

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -436,15 +436,11 @@ function simple_update_1site!(ψ::AbstractAnsatz, gate)
     return contract!(ψ, contracting_index)
 end
 
-function simple_update_2site!(
-    ::MixedCanonical, ψ::AbstractAnsatz, gate; kwargs...
-)
+function simple_update_2site!(::MixedCanonical, ψ::AbstractAnsatz, gate; kwargs...)
     return simple_update_2site!(NonCanonical(), ψ, gate; kwargs...)
 end
 
-function simple_update_2site!(
-    ::NonCanonical, ψ::AbstractAnsatz, gate; kwargs...
-)
+function simple_update_2site!(::NonCanonical, ψ::AbstractAnsatz, gate; kwargs...)
     @assert has_edge(ψ, lanes(gate)...) "Gate must act on neighboring sites"
 
     # shallow copy to avoid problems if errors in mid execution

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -477,9 +477,7 @@ function simple_update_2site!(::NonCanonical, ψ::AbstractAnsatz, gate; kwargs..
     svd!(ψ; left_inds=linds, right_inds=rinds, virtualind=vind)
 
     # truncate virtual index
-    if any(!isnothing, get.(Ref(kwargs), [:threshold, :maxdim], nothing))
-        truncate!(ψ, collect(bond); kwargs...)
-    end
+    truncate!(ψ, collect(bond); kwargs...)
 
     return ψ
 end

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -267,11 +267,9 @@ Truncate the dimension of the virtual `bond`` of an [`Ansatz`](@ref) Tensor Netw
   - Either `threshold` or `maxdim` must be provided. If both are provided, `maxdim` is used.
 """
 function truncate!(tn::AbstractAnsatz, bond; threshold=nothing, maxdim=nothing, kwargs...)
-    if all(isnothing, (threshold, maxdim))
-        return tn
-    else
-        return truncate!(form(tn), tn, bond; threshold, maxdim, kwargs...)
-    end
+    all(isnothing, (threshold, maxdim)) && return tn
+
+    return truncate!(form(tn), tn, bond; threshold, maxdim, kwargs...)
 end
 
 """

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -267,7 +267,11 @@ Truncate the dimension of the virtual `bond`` of an [`Ansatz`](@ref) Tensor Netw
   - Either `threshold` or `maxdim` must be provided. If both are provided, `maxdim` is used.
 """
 function truncate!(tn::AbstractAnsatz, bond; threshold=nothing, maxdim=nothing, kwargs...)
-    return truncate!(form(tn), tn, bond; threshold, maxdim, kwargs...)
+    if all(isnothing, (threshold, maxdim))
+        return tn
+    else
+        return truncate!(form(tn), tn, bond; threshold, maxdim, kwargs...)
+    end
 end
 
 """

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -437,13 +437,13 @@ function simple_update_1site!(ψ::AbstractAnsatz, gate)
 end
 
 function simple_update_2site!(
-    ::MixedCanonical, ψ::AbstractAnsatz, gate; threshold=nothing, maxdim=nothing, normalize=false
+    ::MixedCanonical, ψ::AbstractAnsatz, gate; threshold=nothing, maxdim=nothing, normalize=false, kwargs...
 )
-    return simple_update_2site!(NonCanonical(), ψ, gate; threshold, maxdim, normalize)
+    return simple_update_2site!(NonCanonical(), ψ, gate; threshold, maxdim, normalize, kwargs...)
 end
 
 function simple_update_2site!(
-    ::NonCanonical, ψ::AbstractAnsatz, gate; threshold=nothing, maxdim=nothing, normalize=false
+    ::NonCanonical, ψ::AbstractAnsatz, gate; threshold=nothing, maxdim=nothing, normalize=false, kwargs...
 )
     @assert has_edge(ψ, lanes(gate)...) "Gate must act on neighboring sites"
 
@@ -478,7 +478,7 @@ function simple_update_2site!(
 
     # truncate virtual index
     if any(!isnothing, (threshold, maxdim))
-        truncate!(ψ, collect(bond); threshold, maxdim, normalize)
+        truncate!(ψ, collect(bond); threshold, maxdim, normalize, kwargs...)
     end
 
     return ψ
@@ -497,7 +497,7 @@ function simple_update_2site!(::Canonical, ψ::AbstractAnsatz, gate; threshold, 
     !isnothing(Λᵢ₋₁) && contract!(ψ; between=(Site(id(sitel) - 1), sitel), direction=:right, delete_Λ=false)
     !isnothing(Λᵢ₊₁) && contract!(ψ; between=(siter, Site(id(siter) + 1)), direction=:left, delete_Λ=false)
 
-    simple_update_2site!(NonCanonical(), ψ, gate; threshold, maxdim, normalize=false)
+    simple_update_2site!(NonCanonical(), ψ, gate; threshold, maxdim, normalize=false, canonize=false)
 
     # contract the updated tensors with the inverse of Λᵢ and Λᵢ₊₂, to get the new Γ tensors
     U, Vt = tensors(ψ; at=sitel), tensors(ψ; at=siter)

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -640,9 +640,7 @@ function truncate_sweep!(::NonCanonical, ψ::AbstractMPO; kwargs...)
     for i in 1:(nsites(ψ) - 1)
         canonize_site!(ψ, Site(i); direction=:right, method=:svd)
 
-        any(!isnothing, get.(Ref(kwargs), [:threshold, :maxdim], nothing)) &&
-            truncate!(ψ, [Site(i), Site(i + 1)]; kwargs..., compute_local_svd=false)
-
+        truncate!(ψ, [Site(i), Site(i + 1)]; kwargs..., compute_local_svd=false)
         contract!(ψ; between=(Site(i), Site(i + 1)), direction=:right)
     end
 
@@ -663,8 +661,7 @@ function truncate_sweep!(::Canonical, ψ::AbstractMPO; kwargs...)
     # left-to-right SVD sweep, get left-canonical tensors and singular values and truncate
     for i in 1:(nsites(ψ) - 1)
         canonize_site!(ψ, Site(i); direction=:right, method=:svd)
-        any(!isnothing, get.(Ref(kwargs), [:threshold, :maxdim], nothing)) &&
-            truncate!(ψ, [Site(i), Site(i + 1)]; kwargs..., compute_local_svd=false)
+        truncate!(ψ, [Site(i), Site(i + 1)]; kwargs..., compute_local_svd=false)
     end
 
     canonize!(ψ)


### PR DESCRIPTION
This PR includes changes to `evolve`-related functions to add support for additional keyword arguments (`kwargs...`) in several functions. This enhancement allows for more flexible function calls by passing extra parameters as needed.

This is useful for example when we want to pass a `kwarg` into `truncate`. 
