### PR TITLE
Refactor `inds(::Tensor)` to return `Tuple`

### DIFF
--- a/ext/TenetChainRulesCoreExt/projectors.jl
+++ b/ext/TenetChainRulesCoreExt/projectors.jl
@@ -1,6 +1,6 @@
 # `Tensor` projector
 function ChainRulesCore.ProjectTo(tensor::T) where {T<:Tensor}
-    return ProjectTo{T}(; data=ProjectTo(tensor.data), inds=tensor.inds)
+    return ProjectTo{T}(; data=ProjectTo(parent(tensor)), inds=inds(tensor))
 end
 
 function (projector::ProjectTo{T})(dx::T) where {T<:Tensor}

--- a/ext/TenetChainRulesCoreExt/rrules.jl
+++ b/ext/TenetChainRulesCoreExt/rrules.jl
@@ -69,8 +69,8 @@ function ChainRulesCore.rrule(::typeof(Base.merge), a::TensorNetwork, b::TensorN
     c = merge(a, b)
 
     function merge_pullback(c̄)
-        ā = TensorNetworkTangent([c̄.tensors[inds(tensor)] for tensor in tensors(a)])
-        b̄ = TensorNetworkTangent([c̄.tensors[inds(tensor)] for tensor in tensors(b)])
+        ā = TensorNetworkTangent([c̄[inds(tensor)] for tensor in tensors(a)])
+        b̄ = TensorNetworkTangent([c̄[inds(tensor)] for tensor in tensors(b)])
         return NoTangent(), ā, b̄
     end
     merge_pullback(c̄::AbstractVector) = merge_pullback(TensorNetworkTangent(c̄))

--- a/ext/TenetChainRulesCoreExt/tangents.jl
+++ b/ext/TenetChainRulesCoreExt/tangents.jl
@@ -5,7 +5,7 @@ struct TensorNetworkTangent <: AbstractTangent
 end
 
 function TensorNetworkTangent(tensors::Vector{<:Tensor})
-    return TensorNetworkTangent(Dict(inds(tensor) => tensor for tensor in tensors))
+    return TensorNetworkTangent(Dict(collect(inds(tensor)) => tensor for tensor in tensors))
 end
 
 Tenet.tensors(tn::TensorNetworkTangent) = sort!(collect(values(tn.tensors)); by=inds)
@@ -50,3 +50,5 @@ Base.merge(Δa::TensorNetworkTangent, Δb::TensorNetworkTangent) = Δa + Δb
 
 Base.conj(Δ::Tangent{<:Tensor}) = Tangent{Tensor}(; data=conj(Δ.data), inds=NoTangent())
 Base.conj(Δ::TensorNetworkTangent) = TensorNetworkTangent(Dict(inds => conj(t) for (inds, t) in Δ.tensors))
+
+Base.getindex(Δ::TensorNetworkTangent, i::Base.AbstractVecOrTuple{Symbol}) = getindex(Δ.tensors, collect(i))

--- a/ext/TenetKrylovKitExt.jl
+++ b/ext/TenetKrylovKitExt.jl
@@ -27,6 +27,7 @@ end
 
 function eigsolve_prehook_tensor_reshape(A::Tensor, x₀::Tensor, left_inds, right_inds)
     left_inds, right_inds = Tenet.factorinds(A, left_inds, right_inds)
+    left_inds, right_inds = Tuple(left_inds), Tuple(right_inds)
 
     Amat, left_sizes, right_sizes = eigsolve_prehook_tensor_reshape(A, left_inds, right_inds)
     prod_left_sizes = prod(left_sizes)
@@ -54,8 +55,8 @@ function KrylovKit.eigsolve(
     howmany::Int=1,
     which::KrylovKit.Selector=:LM,
     T::Type=eltype(A);
-    left_inds=Symbol[],
-    right_inds=Symbol[],
+    left_inds=(),
+    right_inds=(),
     kwargs...,
 )
     Amat, left_sizes, right_sizes = eigsolve_prehook_tensor_reshape(A, left_inds, right_inds)
@@ -85,8 +86,8 @@ function KrylovKit.eigsolve(
     howmany::Int,
     which::KrylovKit.Selector,
     alg::Algorithm;
-    left_inds=Symbol[],
-    right_inds=Symbol[],
+    left_inds=(),
+    right_inds=(),
     kwargs...,
 ) where {Algorithm<:KrylovKit.Lanczos} # KrylovKit.KrylovAlgorithm}
     Amat, left_sizes, right_sizes = eigsolve_prehook_tensor_reshape(A, left_inds, right_inds)
@@ -107,7 +108,7 @@ function KrylovKit.eigsolve(
     which::KrylovKit.Selector,
     alg::Algorithm;
     left_inds=inds(x₀),
-    right_inds=Symbol[],
+    right_inds=(),
     kwargs...,
 ) where {Algorithm<:KrylovKit.Lanczos} # KrylovKit.KrylovAlgorithm}
     Amat, left_sizes, right_sizes, x₀vec = eigsolve_prehook_tensor_reshape(A, x₀, left_inds, right_inds)

--- a/ext/TenetKrylovKitExt.jl
+++ b/ext/TenetKrylovKitExt.jl
@@ -51,13 +51,7 @@ function eigsolve_prehook_tensor_reshape(A::Tensor, x₀::Tensor, left_inds, rig
 end
 
 function KrylovKit.eigsolve(
-    A::Tensor,
-    howmany::Int=1,
-    which::KrylovKit.Selector=:LM,
-    T::Type=eltype(A);
-    left_inds=(),
-    right_inds=(),
-    kwargs...,
+    A::Tensor, howmany::Int=1, which::KrylovKit.Selector=:LM, T::Type=eltype(A); left_inds=(), right_inds=(), kwargs...
 )
     Amat, left_sizes, right_sizes = eigsolve_prehook_tensor_reshape(A, left_inds, right_inds)
 
@@ -81,14 +75,7 @@ Perform eigenvalue decomposition on a tensor.
   - `right_inds`: right indices to be used in the eigenvalue decomposition. Defaults to all indices of `t` except `left_inds`.
 """
 function KrylovKit.eigsolve(
-    A::Tensor,
-    x₀,
-    howmany::Int,
-    which::KrylovKit.Selector,
-    alg::Algorithm;
-    left_inds=(),
-    right_inds=(),
-    kwargs...,
+    A::Tensor, x₀, howmany::Int, which::KrylovKit.Selector, alg::Algorithm; left_inds=(), right_inds=(), kwargs...
 ) where {Algorithm<:KrylovKit.Lanczos} # KrylovKit.KrylovAlgorithm}
     Amat, left_sizes, right_sizes = eigsolve_prehook_tensor_reshape(A, left_inds, right_inds)
 

--- a/ext/TenetReactantExt.jl
+++ b/ext/TenetReactantExt.jl
@@ -13,7 +13,7 @@ function Reactant.make_tracer(
     seen, @nospecialize(prev::RT), path::Tuple, mode::Reactant.TraceMode; kwargs...
 ) where {RT<:Tensor}
     tracedata = Reactant.make_tracer(seen, parent(prev), Reactant.append_path(path, :data), mode; kwargs...)
-    return Tensor(tracedata, copy(inds(prev)))
+    return Tensor(tracedata, inds(prev))
 end
 
 function Reactant.make_tracer(seen, prev::TensorNetwork, path::Tuple, mode::Reactant.TraceMode; kwargs...)
@@ -51,7 +51,7 @@ end
 
 function Reactant.create_result(@nospecialize(tocopy::Tensor), @nospecialize(path), result_stores)
     data = Reactant.create_result(parent(tocopy), Reactant.append_path(path, :data), result_stores)
-    return :($Tensor($data, $(copy(inds(tocopy)))))
+    return :($Tensor($data, $(inds(tocopy))))
 end
 
 function Reactant.create_result(tocopy::TensorNetwork, @nospecialize(path), result_stores)

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -178,7 +178,7 @@ Return the [`Tensor`](@ref) in a virtual bond between two [`Site`](@ref)s in a [
 @kwmethod function tensors(tn::AbstractAnsatz; bond)
     vind = inds(tn; bond)
     tensor = filter(tensors(tn)) do tensor
-        [vind] == inds(tensor)
+        (vind,) == inds(tensor)
     end
     isempty(tensor) && throw(MissingSchmidtCoefficientsException(bond))
     return only(tensor)

--- a/src/Helpers.jl
+++ b/src/Helpers.jl
@@ -25,9 +25,9 @@ letter(i) = Symbol(first(iterate(Iterators.drop(Iterators.filter(isletter, Itera
 
 # NOTE from https://stackoverflow.com/q/54652787
 function nonunique(x)
-    uniqueindexes = indexin(unique(x), x)
+    uniqueindexes = indexin(unique(x), collect(x))
     nonuniqueindexes = setdiff(1:length(x), uniqueindexes)
-    return unique(x[nonuniqueindexes])
+    return Tuple(unique(x[nonuniqueindexes]))
 end
 
 struct IndexCounter

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -58,8 +58,8 @@ function allocate_result(
     ib = collect(inds(b))
     i = ∩(dims, ia, ib)
 
-    ic::Vector{Symbol} = if isnothing(out)
-        setdiff(ia ∪ ib, i isa Base.AbstractVecOrTuple ? i : (i,))::Vector{Symbol}
+    ic = if isnothing(out)
+        Tuple(setdiff(ia ∪ ib, i isa Base.AbstractVecOrTuple ? i : (i,)))
     else
         out
     end

--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -40,7 +40,7 @@ Tensor(data::Number) = Tensor(fill(data))
 
 Return the indices of the tensor in the order of the dimensions.
 """
-inds(t::Tensor) = t.inds
+inds(t::Tensor) = Tuple(t.inds)
 
 function Base.copy(t::Tensor{T,N,<:SubArray{T,N}}) where {T,N}
     data = copy(t.data)

--- a/src/Tensor.jl
+++ b/src/Tensor.jl
@@ -11,10 +11,11 @@ struct Tensor{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
     data::A
     inds::Vector{Symbol}
 
-    function Tensor{T,N,A}(data::A, inds::AbstractVector) where {T,N,A<:AbstractArray{T,N}}
+    function Tensor{T,N,A}(data::A, inds) where {T,N,A<:AbstractArray{T,N}}
+        inds = collect(inds)
         length(inds) == N ||
             throw(ArgumentError("ndims(data) [$(ndims(data))] must be equal to length(inds) [$(length(inds))]"))
-        all(i -> allequal(Iterators.map(dim -> size(data, dim), findall(==(i), inds))), nonunique(collect(inds))) ||
+        all(i -> allequal(Iterators.map(dim -> size(data, dim), findall(==(i), inds))), nonunique(inds)) ||
             throw(DimensionMismatch("nonuniform size of repeated indices"))
 
         return new{T,N,A}(data, inds)

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -53,7 +53,7 @@ struct TensorNetwork <: AbstractTensorNetwork
 
     # TODO: Find a way to remove the `unsafe` keyword argument from the constructor
     function TensorNetwork(tensors; unsafe::Union{Nothing,UnsafeScope}=nothing)
-        tensormap = IdDict{Tensor,Vector{Symbol}}(tensor => inds(tensor) for tensor in tensors)
+        tensormap = IdDict{Tensor,Vector{Symbol}}(tensor => collect(inds(tensor)) for tensor in tensors)
 
         indexmap = reduce(tensors; init=Dict{Symbol,Vector{Tensor}}()) do dict, tensor
             for index in inds(tensor)
@@ -210,7 +210,7 @@ function tensors end
 @kwmethod function tensors(tn::AbstractTensorNetwork;)
     tn = TensorNetwork(tn)
     get!(tn.sorted_tensors) do
-        sort!(collect(keys(tn.tensormap)); by=sort ∘ inds)
+        sort!(collect(keys(tn.tensormap)); by=sort ∘ collect ∘ inds)
     end
 end
 

--- a/test/Ansatz_test.jl
+++ b/test/Ansatz_test.jl
@@ -87,7 +87,7 @@ using LinearAlgebra
             )
             @test expect(ansatz, gate) ≈ 4.0
             @testset let ψ = simple_update!(copy(ansatz), gate)
-                @test tensors(simple_update!(copy(ansatz), gate); bond=(site"1", site"2")) ≈ Tensor([2, 0], [:i])
+                @test tensors(ψ; bond=(site"1", site"2")) ≈ Tensor([2, 0], [:i])
             end
         end
     end

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -22,7 +22,7 @@
 
             C = contract(A; dims=(:i,))
             C_ein = ein"ijk -> jk"(parent(A))
-            @test inds(C) == [:j, :k]
+            @test inds(C) == (:j, :k)
             @test size(C) == size(C_ein) == (3, 4)
             @test parent(C) ≈ C_ein
         end
@@ -32,7 +32,7 @@
 
             C = contract(A; dims=())
             C_ein = ein"iji -> ij"(parent(A))
-            @test inds(C) == [:i, :j]
+            @test inds(C) == (:i, :j)
             @test size(C) == size(C_ein) == (2, 3)
             @test parent(C) ≈ C_ein
         end
@@ -42,7 +42,7 @@
 
             C = contract(A; dims=(:i,))
             C_ein = ein"iji -> j"(parent(A))
-            @test inds(C) == [:j]
+            @test inds(C) == (:j,)
             @test size(C) == size(C_ein) == (3,)
             @test parent(C) ≈ C_ein
         end
@@ -53,7 +53,7 @@
 
             C = contract(A, B)
             C_mat = parent(A) * parent(B)
-            @test inds(C) == [:i, :k]
+            @test inds(C) == (:i, :k)
             @test size(C) == (2, 4) == size(C_mat)
             @test parent(C) ≈ parent(A * B) ≈ C_mat
         end
@@ -64,7 +64,7 @@
 
             C = contract(A, B)
             C_res = LinearAlgebra.tr(parent(A) * parent(B))
-            @test inds(C) == Symbol[]
+            @test inds(C) == ()
             @test size(C) == () == size(C_res)
             @test only(C) ≈ C_res
         end
@@ -76,7 +76,7 @@
             C = contract(A, B)
             C_ein = ein"ij, kl -> ijkl"(parent(A), parent(B))
             @test size(C) == (2, 2, 2, 2) == size(C_ein)
-            @test inds(C) == [:i, :j, :k, :l]
+            @test inds(C) == (:i, :j, :k, :l)
             @test parent(C) ≈ C_ein
         end
 
@@ -85,12 +85,12 @@
             scalar = 2.0
 
             C = contract(A, scalar)
-            @test inds(C) == [:i, :j]
+            @test inds(C) == (:i, :j)
             @test size(C) == (2, 2)
             @test parent(C) ≈ parent(A) * scalar
 
             D = contract(scalar, A)
-            @test inds(D) == [:i, :j]
+            @test inds(D) == (:i, :j)
             @test size(D) == (2, 2)
             @test parent(D) ≈ scalar * parent(A)
         end
@@ -102,14 +102,14 @@
             # Contraction of all common indices
             C = contract(A, B; dims=(:j, :k))
             C_ein = ein"ijk, klj -> il"(parent(A), parent(B))
-            @test inds(C) == [:i, :l]
+            @test inds(C) == (:i, :l)
             @test size(C) == (2, 5) == size(C_ein)
             @test parent(C) ≈ C_ein
 
             # Contraction of not all common indices
             C = contract(A, B; dims=(:j,))
             C_ein = ein"ijk, klj -> ikl"(parent(A), parent(B))
-            @test inds(C) == [:i, :k, :l]
+            @test inds(C) == (:i, :k, :l)
             @test size(C) == (2, 4, 5) == size(C_ein)
             @test parent(C) ≈ C_ein
 
@@ -119,7 +119,7 @@
 
                 C = contract(A, B; dims=(:j, :k))
                 C_ein = ein"ijk, klj -> il"(parent(A), parent(B))
-                @test inds(C) == [:i, :l]
+                @test inds(C) == (:i, :l)
                 @test size(C) == (2, 5) == size(C_ein)
                 @test parent(C) ≈ C_ein
             end
@@ -158,9 +158,9 @@
 
         U, s, V = svd(tensor; left_inds=[:i, :j], virtualind=:x)
 
-        @test inds(U) == [:i, :j, :x]
-        @test inds(s) == [:x]
-        @test inds(V) == [:k, :l, :x]
+        @test inds(U) == (:i, :j, :x)
+        @test inds(s) == (:x,)
+        @test inds(V) == (:k, :l, :x)
 
         @test size(U) == (2, 4, 8)
         @test size(s) == (8,)
@@ -190,8 +190,8 @@
 
         Q, R = qr(tensor; left_inds=(:i, :j), virtualind=vidx)
 
-        @test inds(Q) == [:i, :j, :x]
-        @test inds(R) == [:x, :k, :l]
+        @test inds(Q) == (:i, :j, :x)
+        @test inds(R) == (:x, :k, :l)
 
         @test size(Q) == (2, 4, 8)
         @test size(R) == (8, 6, 8)
@@ -219,9 +219,9 @@
         @test_throws ArgumentError lu(tensor, left_inds=(:i, :j), virtualind=(:j, :k))
 
         L, U, P = lu(tensor; left_inds=[:i, :j], virtualind=vidx)
-        @test inds(L) == [:x, :y]
-        @test inds(U) == [:y, :k, :l]
-        @test inds(P) == [:i, :j, :x]
+        @test inds(L) == (:x, :y)
+        @test inds(U) == (:y, :k, :l)
+        @test inds(P) == (:i, :j, :x)
 
         @test size(L) == (8, 8)
         @test size(U) == (8, 6, 8)

--- a/test/TensorNetwork_test.jl
+++ b/test/TensorNetwork_test.jl
@@ -1,6 +1,7 @@
 @testset "TensorNetwork" begin
     using Serialization
     using Graphs: neighbors
+    using LinearAlgebra
 
     @testset "Constructors" begin
         @testset "empty" begin
@@ -585,7 +586,7 @@
             replace!(tn, old_new...)
 
             @test issetequal(
-                inds.(tensors(tn)), [[:A, :P, :L], [:L, :B, :K, :U], [:U, :C, :V, :O], [:O, :D, :J, :N], [:N, :E, :M]]
+                inds.(tensors(tn)), [(:A, :P, :L), (:L, :B, :K, :U), (:U, :C, :V, :O), (:O, :D, :J, :N), (:N, :E, :M)]
             )
         end
     end

--- a/test/Tensor_test.jl
+++ b/test/Tensor_test.jl
@@ -10,7 +10,7 @@
             data = ones(2, 2, 2)
             tensor = Tensor(data, [:i, :j, :k])
 
-            @test inds(tensor) == [:i, :j, :k]
+            @test inds(tensor) == (:i, :j, :k)
             @test parent(tensor) === data
 
             @test_throws DimensionMismatch Tensor(zeros(2, 3), (:i, :i))
@@ -44,7 +44,7 @@
         @test parent(similar(tensor)) !== parent(tensor)
         @test inds(similar(tensor)) == inds(tensor)
 
-        @test inds(similar(tensor; inds=[:a, :b, :c])) == [:a, :b, :c]
+        @test inds(similar(tensor; inds=[:a, :b, :c])) == (:a, :b, :c)
 
         @test eltype(similar(tensor, Bool)) == Bool
         @test size(similar(tensor, Bool)) == size(tensor)
@@ -151,10 +151,10 @@
 
     @testset "Base.replace" begin
         tensor = Tensor(zeros(2, 2, 2), (:i, :j, :k))
-        @test inds(replace(tensor, :i => :u, :j => :v, :k => :w)) == [:u, :v, :w]
+        @test inds(replace(tensor, :i => :u, :j => :v, :k => :w)) == (:u, :v, :w)
         @test parent(replace(tensor, :i => :u, :j => :v, :k => :w)) === parent(tensor)
 
-        @test inds(replace(tensor, :a => :u, :b => :v, :c => :w)) == [:i, :j, :k]
+        @test inds(replace(tensor, :a => :u, :b => :v, :c => :w)) == (:i, :j, :k)
         @test parent(replace(tensor, :a => :u, :b => :v, :c => :w)) === parent(tensor)
     end
 
@@ -214,7 +214,7 @@
         tensor = Tensor(data, (:i, :j, :k))
         perm = (3, 1, 2)
 
-        @test inds(permutedims(tensor, perm)) == [:k, :i, :j]
+        @test inds(permutedims(tensor, perm)) == (:k, :i, :j)
         @test parent(permutedims(tensor, perm)) == permutedims(data, perm)
 
         newtensor = Tensor(similar(data), (:a, :b, :c))
@@ -258,7 +258,7 @@
         @testset "scalar" begin
             tensor = Tensor(fill(1.0 + 1.0im), Symbol[])
 
-            @test inds(conj(tensor)) == Symbol[]
+            @test inds(conj(tensor)) == ()
             @test isapprox(conj(tensor), 1.0 - 1.0im)
             @test adjoint(tensor) == conj(tensor)
         end
@@ -267,7 +267,7 @@
             data = fill(1.0 + 1.0im, 2)
             tensor = Tensor(data, (:i,))
 
-            @test inds(conj(tensor)) == [:i]
+            @test inds(conj(tensor)) == (:i,)
             @test all(isapprox.(conj(tensor), fill(1.0 - 1.0im, size(data)...)))
             @test adjoint(tensor) == conj(tensor)
         end
@@ -276,7 +276,7 @@
             data = fill(1.0 + 1.0im, 2, 2)
             tensor = Tensor(data, (:i, :j))
 
-            @test inds(adjoint(tensor)) == [:i, :j]
+            @test inds(adjoint(tensor)) == (:i, :j)
             @test all(isapprox.(conj(tensor), fill(1.0 - 1.0im, size(data)...)))
             @test adjoint(tensor) == conj(tensor)
         end
@@ -287,7 +287,7 @@
             data = rand(Complex{Float64}, 2)
             tensor = Tensor(data, (:i,))
 
-            @test inds(transpose(tensor)) == [:i]
+            @test inds(transpose(tensor)) == (:i,)
             @test ndims(transpose(tensor)) == 1
             @test all(isapprox.(transpose(tensor), data))
         end
@@ -296,7 +296,7 @@
             data = rand(Complex{Float64}, 2, 2)
             tensor = Tensor(data, (:i, :j))
 
-            @test inds(transpose(tensor)) == [:j, :i]
+            @test inds(transpose(tensor)) == (:j, :i)
             @test ndims(transpose(tensor)) == 2
             @test all(isapprox.(transpose(tensor), transpose(data)))
         end
@@ -307,26 +307,26 @@
         tensor = Tensor(data, (:i, :j, :k))
 
         let new = expand(tensor; label=:x, axis=1)
-            @test inds(new) == [:x, :i, :j, :k]
+            @test inds(new) == (:x, :i, :j, :k)
             @test size(new, :x) == 1
             @test selectdim(new, :x, 1) == tensor
         end
 
         let new = expand(tensor; label=:x, axis=3)
-            @test inds(new) == [:i, :j, :x, :k]
+            @test inds(new) == (:i, :j, :x, :k)
             @test size(new, :x) == 1
             @test selectdim(new, :x, 1) == tensor
         end
 
         let new = expand(tensor; label=:x, axis=1, size=2, method=:zeros)
-            @test inds(new) == [:x, :i, :j, :k]
+            @test inds(new) == (:x, :i, :j, :k)
             @test size(new, :x) == 2
             @test selectdim(new, :x, 1) == tensor
             @test selectdim(new, :x, 2) == Tensor(zeros(size(data)...), inds(tensor))
         end
 
         let new = expand(tensor; label=:x, axis=1, size=2, method=:repeat)
-            @test inds(new) == [:x, :i, :j, :k]
+            @test inds(new) == (:x, :i, :j, :k)
             @test size(new, :x) == 2
             @test selectdim(new, :x, 1) == tensor
             @test selectdim(new, :x, 2) == tensor

--- a/test/integration/Dagger_test.jl
+++ b/test/integration/Dagger_test.jl
@@ -34,7 +34,7 @@ using Distributed
                 contracted_block_tensor = contract(block_tensor1, block_tensor2)
 
                 @test parent(contracted_block_tensor) isa DArray
-                @test inds(contracted_block_tensor) == [:i, :k]
+                @test inds(contracted_block_tensor) == (:i, :k)
                 @test all(==((2, 2)) ∘ size, Dagger.domainchunks(parent(contracted_block_tensor)))
                 @test collect(parent(contracted_block_tensor)) ≈ parent(contracted_tensor)
             end

--- a/test/integration/KrylovKit_test.jl
+++ b/test/integration/KrylovKit_test.jl
@@ -1,6 +1,7 @@
 @testset "KrylovKit.eigsolve" begin
     using Tenet: Tensor
     using KrylovKit
+    using LinearAlgebra
 
     A = rand(ComplexF64, 4, 4)
     data = (A + A') / 2 # Make it Hermitian
@@ -13,7 +14,7 @@
     @test length(vecs) == 4
 
     for vec in vecs
-        @test inds(vec) == [:i]
+        @test inds(vec) == (:i,)
         @test size(vec) == (4,)
     end
 


### PR DESCRIPTION
Current implementation of `inds(::Tensor)` is to return the `Vector{Symbol}`, but this has the problem that mutating will modify the one from the original tensor too.