### PR TITLE
Update `MPS` manual in docs

### DIFF
--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -20,7 +20,7 @@ Currently only `Open` boundary conditions are supported in Tenet.
 fig = Figure() # hide
 open_mps = rand(MPS; n=10, maxdim=4)
 
-plot!(fig[1,1], open_mps, layout=Spring(iterations=1000, C=0.5, seed=100)) # hide
+graphplot!(fig[1,1], open_mps, layout=Spring(iterations=1000, C=0.5, seed=100)) # hide
 Label(fig[1,1, Bottom()], "Open") # hide
 
 fig # hide
@@ -104,7 +104,7 @@ The major difference between them is that MPOs have 2 indices per site (1 input 
 fig = Figure() # hide
 open_mpo = rand(MPO, n=10, maxdim=4)
 
-plot!(fig[1,1], open_mpo, layout=Spring(iterations=1000, C=0.5, seed=100)) # hide
+graphplot!(fig[1,1], open_mpo, layout=Spring(iterations=1000, C=0.5, seed=100)) # hide
 Label(fig[1,1, Bottom()], "Open") # hide
 
 fig # hide

--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -14,46 +14,46 @@ using NetworkLayout
 Matrix Product States ([`MPS`](@ref)) are a Quantum Tensor Network [`Ansatz`](@ref) whose tensors are laid out in a 1D chain.
 Due to this, these networks are also known as _Tensor Trains_ in other scientific fields.
 Depending on the boundary conditions, these chains can be open or closed (i.e. periodic boundary conditions).
-Currently only `Open` boundary conditions are supported in Tenet.
+
+!!! warning
+    Currently only [`Open`](@ref) boundary conditions are supported in Tenet.
 
 ```@example examples
 fig = Figure() # hide
-open_mps = rand(MPS; n=10, maxdim=4)
+open_mps = rand(MPS; n=10, maxdim=4) # hide
 
 graphplot!(fig[1,1], open_mps, layout=Spring(iterations=1000, C=0.5, seed=100)) # hide
-Label(fig[1,1, Bottom()], "Open") # hide
+Label(fig[1,1, Bottom()], "Open MPS") # hide
 
 fig # hide
 ```
 
 In Tenet, a Matrix Product State can be easily created by passing a list of arrays to the [`MPS`](@ref) constructor:
 ```@repl examples
-mps = MPS([rand(2, 2), rand(2, 2, 4), rand(2, 4, 2), rand(2, 2)])
+ψ = MPS([rand(2, 2), rand(2, 2, 4), rand(2, 4, 2), rand(2, 2)])
 ```
 
 The default ordering of the indices on the [`MPS`](@ref) constructor is (physical, left, right), but you can specify the ordering by passing the `order` keyword argument:
 
 ```@repl examples
-mps = MPS([rand(2, 2), rand(2, 2, 4), rand(4, 2, 2), rand(2, 2)]; order=[:l, :o, :r])
+ϕ = MPS([rand(2, 2), rand(2, 2, 4), rand(4, 2, 2), rand(2, 2)]; order=[:l, :o, :r])
 ```
 where `:l`, `:r`, and `:o` represent the left, right, and outer physical indices, respectively.
 
-Additionally, Tenet has the `rand` function to generate random `MPS` with a given number of sites and maximum bond dimension:
+Additionally, Tenet has the [`rand`](@ref) function to generate random [`MPS`](@ref) with a given number of sites and maximum bond dimension:
 
 ```@repl examples
-mps = rand(MPS, n=8, maxdim=10)
+Φ = rand(MPS, n=8, maxdim=10)
 size.(tensors(mps))
 ```
 
 ### Canonical Forms
 
-An [`MPS`](@ref) representation is not unique: a single [`MPS`](@ref) can be represented in different canonical forms. The choice of canonical form can affect the efficiency and stability of algorithms used to manipulate the `MPS`.
-The current form of the [`MPS`](@ref) is stored as the trait [`Form`](@ref) and can be accessed via the `form` function:
+An [`MPS`](@ref) representation is not unique: a single [`MPS`](@ref) can be represented in different canonical forms. The choice of canonical form can affect the efficiency and stability of algorithms used to manipulate the [`MPS`](@ref).
+The current form of the [`MPS`](@ref) is stored as the trait [`Form`](@ref) and can be accessed via the [`form`](@ref) function:
 
 ```@repl examples
-mps = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
-
-form(mps)
+form(ψ)
 ```
 !!! warning
     Depending on the form, Tenet will dispatch under the hood the appropriate algorithm which assumes full use of the canonical form, so be careful when making modifications that might alter the canonical form without changing the trait.
@@ -62,10 +62,10 @@ Tenet has the internal function [`Tenet.check_form`](@ref) to check if the `MPS`
 Currently, Tenet supports the [`NonCanonical`](@ref), [`CanonicalForm`](@ref) and [`MixedCanonical`](@ref) forms.
 
 #### `NonCanonical` Form
-In the `NonCanonical` form, the tensors in the `MPS` do not satisfy any particular orthogonality conditions. This is the default `form` when an `MPS` is initialized without specifying a canonical form. It is useful for general purposes but may not be optimal for certain computations that benefit from orthogonality.
+In the [`NonCanonical`](@ref) form, the tensors in the [`MPS`](@ref) do not satisfy any particular orthogonality conditions. This is the default [`form`](@ref) when an [`MPS`](@ref) is initialized without specifying a canonical form. It is useful for general purposes but may not be optimal for certain computations that benefit from orthogonality.
 
 #### `Canonical` Form
-Also known as Vidal's form, the `Canonical` form represents the `MPS` using a sequence of isometric tensors (`Γ`) and diagonal vectors (`λ`) containing the Schmidt coefficients. The `MPS` is expressed as:
+Also known as Vidal's form, the [`Canonical`](@ref) form represents the [`MPS`](@ref) using a sequence of tensors (`Γ`) and diagonal vectors (`λ`) containing the Schmidt coefficients. The [`MPS`](@ref) is expressed as:
 
 ```math
 | \psi \rangle = \sum_{i_1, \dots, i_N} \Gamma_1^{i_1} \lambda_2 \Gamma_2^{i_2} \dots \lambda_{N-1} \Gamma_{N-1}^{i_{N-1}} \lambda_N \Gamma_N^{i_N} | i_1, \dots, i_N \rangle \, .
@@ -74,31 +74,29 @@ Also known as Vidal's form, the `Canonical` form represents the `MPS` using a se
 You can convert an `MPS` to the `Canonical` form by calling `canonize!`:
 
 ```@repl examples
-mps = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
-canonize!(mps)
+canonize!(ψ)
 
-form(mps)
+form(ψ)
 ```
 
 #### `MixedCanonical` Form
-In the `MixedCanonical` form, tensors to the left of the orthogonality center are left-canonical, tensors to the right are right-canonical, and the tensors at the orthogonality center (which can be `Site` or `Vector{<:Site}`) contains the entanglement information between the left and right parts of the chain. The position of the orthogonality center is stored in the `orthog_center` field.
+In the [`MixedCanonical`](@ref) form, tensors to the left of the orthogonality center are left-canonical, tensors to the right are right-canonical, and the tensors at the orthogonality center (which can be [`Site`](@ref) or `Vector{<:Site}`) contains the entanglement information between the left and right parts of the chain. In Tenet, a left (right) canonical `Tensor` is an isometry pointing to the direction right (left). The position of the orthogonality center is stored in the `orthog_center` field.
 
-You can convert an `MPS` to the `MixedCanonical` form and specify the orthogonality center using `mixed_canonize!`. Additionally, one can check that the `MPS` is effectively in mixed canonical form using the functions `isleftcanonical` and `isrightcanonical`, which return `true` if the `Tensor` at that particular site is left or right canonical, respectively.
+You can convert an [`MPS`](@ref) to the [`MixedCanonical`](@ref) form and specify the orthogonality center using [`mixed_canonize!`](@ref). Additionally, one can check that the `MPS` is effectively in mixed canonical form using the function [`isisometry`](@ref), which returns `True` if the [`Tensor`](@ref) at that particular site is an isometry pointing at direction `dir`:
 
 ```@repl examples
-mps = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
-mixed_canonize!(mps, Site(2))
+mixed_canonize!(ψ, Site(2))
 
-isisometry(mps, 1; dir=:right) # Check if the first tensor is left canonical
-isisometry(mps, 3; dir=:left) # Check if the third tensor is right canonical
+isisometry(ψ, 1; dir=:right) # Check if the first tensor is left canonical
+isisometry(ψ, 3; dir=:left) # Check if the third tensor is right canonical
 
-form(mps)
+form(ψ)
 ```
 
 ## Matrix Product Operators (MPO)
 
 Matrix Product Operators ([`MPO`](@ref)) are the operator version of [Matrix Product State (MPS)](#matrix-product-states-mps).
-The major difference between them is that MPOs have 2 indices per site (1 input and 1 output) while MPSs only have 1 index per site (i.e. an output). Currently, only `Open` boundary conditions are supported in Tenet.
+The major difference between them is that MPOs have 2 indices per site (1 input and 1 output) while MPSs only have 1 index per site (i.e. an output). Currently, only [`Open`](@ref) boundary conditions are supported in Tenet.
 
 ```@example examples
 fig = Figure() # hide
@@ -110,21 +108,15 @@ Label(fig[1,1, Bottom()], "Open") # hide
 fig # hide
 ```
 
-To apply an `MPO` to an `MPS`, you can use the `evolve!` function:
+To apply an [`MPO`](@ref) to an [`MPS`](@ref), you can use the [`evolve!`](@ref) function:
 
 ```@repl examples
 mps = rand(MPS; n=6)
 mpo = rand(MPO; n=6)
 
-size.(tensors(mps))
-
 evolve!(mps, mpo; normalize=false)
-
-size.(tensors(mps))
 ```
 
-As we can see, the bond dimension of the `MPS` has increased after applying the `MPO` to it.
-
-##### Additional Resources
+## Additional Resources
 For more in-depth information on Matrix Product States and their canonical forms, you may refer to:
 - Schollwöck, U. (2011). The density-matrix renormalization group in the age of matrix product states. Annals of physics, 326(1), 96-192.

--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -1,24 +1,22 @@
 # Matrix Product States (MPS)
 
-```@setup plot
+```@setup examples
 using Tenet
 using Makie
 Makie.inline!(true)
 set_theme!(resolution=(800,200))
-
 using CairoMakie
 using GraphMakie
 CairoMakie.activate!(type = "svg")
-
 using NetworkLayout
 ```
 
 Matrix Product States ([`MPS`](@ref)) are a Quantum Tensor Network [`Ansatz`](@ref) whose tensors are laid out in a 1D chain.
 Due to this, these networks are also known as _Tensor Trains_ in other scientific fields.
-Depending on the boundary conditions, these chains can be open or closed (i.e. periodic boundary conditions). Currently
-only `Open` boundary conditions are supported in `Tenet`.
+Depending on the boundary conditions, these chains can be open or closed (i.e. periodic boundary conditions).
+Currently only `Open` boundary conditions are supported in Tenet.
 
-```@example plot
+```@example examples
 fig = Figure() # hide
 open_mps = rand(MPS; n=10, maxdim=4)
 
@@ -28,28 +26,40 @@ Label(fig[1,1, Bottom()], "Open") # hide
 fig # hide
 ```
 
-The default ordering of the indices on the `MPS` constructor is (physical, left, right), but you can specify the ordering by passing the `order` keyword argument:
+In Tenet, a Matrix Product State can be easily created by passing a list of arrays to the [`MPS`](@ref) constructor:
+```@repl examples
+mps = MPS([rand(2, 2), rand(2, 4, 2), rand(4, 2, 2) rand(2, 2)])
+```
 
-```@repl plot
-mps = MPS([rand(4, 2), rand(4, 8, 2), rand(8, 2)]; order=[:l, :r, :o])
+The default ordering of the indices on the [`MPS`](@ref) constructor is (physical, left, right), but you can specify the ordering by passing the `order` keyword argument:
+
+```@repl examples
+mps = MPS([rand(2, 2), rand(2, 2, 4), rand(2, 4, 2) rand(2, 2)]; order=[:o, :l, :r])
 ```
 where `:l`, `:r`, and `:o` represent the left, right, and outer physical indices, respectively.
 
+Additionally, Tenet has the `rand` function to generate random `MPS` with a given number of sites and maximum bond dimension:
+
+```@repl examples
+mps = rand(MPS, n=8, maxdim=10)
+size.(tensors(mps))
+```
 
 ### Canonical Forms
 
-An `MPS` representation is not unique: a single `MPS` can be represented in different canonical forms. The choice of canonical form can affect the efficiency and stability of algorithms used to manipulate the `MPS`.
-The current form of the `MPS` is stored as the trait [`Form`](@ref) and can be accessed via the `form` function:
+An [`MPS`](@ref) representation is not unique: a single [`MPS`](@ref) can be represented in different canonical forms. The choice of canonical form can affect the efficiency and stability of algorithms used to manipulate the `MPS`.
+The current form of the [`MPS`](@ref) is stored as the trait [`Form`](@ref) and can be accessed via the `form` function:
 
-```@repl plot
+```@repl examples
 mps = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
 
 form(mps)
 ```
-> :warning: Depending on the form, `Tenet` will dispatch under the hood the appropriate algorithm which assumes full use of the canonical form, so be careful when making modifications that might alter the canonical form without changing the trait.
+!!! warning
+    Depending on the form, Tenet will dispatch under the hood the appropriate algorithm which assumes full use of the canonical form, so be careful when making modifications that might alter the canonical form without changing the trait.
 
-`Tenet` has the internal function [`Tenet.check_form`](@ref) to check if the `MPS` is in the correct canonical form. This function can be used to ensure that the `MPS` is in the correct form before performing any operation that requires it.
-Currently, `Tenet` supports the [`NonCanonical`](@ref), [`CanonicalForm`](@ref) and [`MixedCanonical`](@ref) forms.
+Tenet has the internal function [`Tenet.check_form`](@ref) to check if the `MPS` is in the correct canonical form. This function can be used to ensure that the `MPS` is in the correct form before performing any operation that requires it.
+Currently, Tenet supports the [`NonCanonical`](@ref), [`CanonicalForm`](@ref) and [`MixedCanonical`](@ref) forms.
 
 #### `NonCanonical` Form
 In the `NonCanonical` form, the tensors in the `MPS` do not satisfy any particular orthogonality conditions. This is the default `form` when an `MPS` is initialized without specifying a canonical form. It is useful for general purposes but may not be optimal for certain computations that benefit from orthogonality.
@@ -63,7 +73,7 @@ Also known as Vidal's form, the `Canonical` form represents the `MPS` using a se
 
 You can convert an `MPS` to the `Canonical` form by calling `canonize!`:
 
-```@repl plot
+```@repl examples
 mps = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
 canonize!(mps)
 
@@ -75,7 +85,7 @@ In the `MixedCanonical` form, tensors to the left of the orthogonality center ar
 
 You can convert an `MPS` to the `MixedCanonical` form and specify the orthogonality center using `mixed_canonize!`. Additionally, one can check that the `MPS` is effectively in mixed canonical form using the functions `isleftcanonical` and `isrightcanonical`, which return `true` if the `Tensor` at that particular site is left or right canonical, respectively.
 
-```@repl plot
+```@repl examples
 mps = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
 mixed_canonize!(mps, Site(2))
 
@@ -85,17 +95,12 @@ isisometry(mps, 3; dir=:left) # Check if the third tensor is right canonical
 form(mps)
 ```
 
-##### Additional Resources
-For more in-depth information on Matrix Product States and their canonical forms, you may refer to:
-- Schollwöck, U. (2011). The density-matrix renormalization group in the age of matrix product states. Annals of physics, 326(1), 96-192.
-
-
 ## Matrix Product Operators (MPO)
 
 Matrix Product Operators ([`MPO`](@ref)) are the operator version of [Matrix Product State (MPS)](#matrix-product-states-mps).
-The major difference between them is that MPOs have 2 indices per site (1 input and 1 output) while MPSs only have 1 index per site (i.e. an output). Currently, only `Open` boundary conditions are supported in `Tenet`.
+The major difference between them is that MPOs have 2 indices per site (1 input and 1 output) while MPSs only have 1 index per site (i.e. an output). Currently, only `Open` boundary conditions are supported in Tenet.
 
-```@example plot
+```@example examples
 fig = Figure() # hide
 open_mpo = rand(MPO, n=10, maxdim=4)
 
@@ -107,7 +112,7 @@ fig # hide
 
 To apply an `MPO` to an `MPS`, you can use the `evolve!` function:
 
-```@repl plot
+```@repl examples
 mps = rand(MPS; n=6)
 mpo = rand(MPO; n=6)
 
@@ -119,3 +124,7 @@ size.(tensors(mps))
 ```
 
 As we can see, the bond dimension of the `MPS` has increased after applying the `MPO` to it.
+
+##### Additional Resources
+For more in-depth information on Matrix Product States and their canonical forms, you may refer to:
+- Schollwöck, U. (2011). The density-matrix renormalization group in the age of matrix product states. Annals of physics, 326(1), 96-192.

--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -42,7 +42,7 @@ Additionally, Tenet has the [`rand`](@ref) function to generate random [`MPS`](@
 
 ```@repl examples
 Φ = rand(MPS, n=8, maxdim=10)
-size.(tensors(mps))
+size.(tensors(Φ))
 ```
 
 ### Canonical Forms
@@ -110,9 +110,8 @@ To apply an [`MPO`](@ref) to an [`MPS`](@ref), you can use the [`evolve!`](@ref)
 
 ```@repl examples
 mps = rand(MPS; n=6)
-mpo = rand(MPO; n=6)
 
-evolve!(mps, mpo; normalize=false)
+evolve!(mps, open_mpo; normalize=false)
 ```
 
 ## Additional Resources

--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -1,8 +1,9 @@
 # Matrix Product States (MPS)
 
-Matrix Product States (MPS) are a Quantum Tensor Network ansatz whose tensors are laid out in a 1D chain.
-Due to this, these networks are also known as _Tensor Trains_ in other mathematical fields.
-Depending on the boundary conditions, the chains can be open or closed (i.e. periodic boundary conditions).
+Matrix Product States ([`MPS`](@ref)) are a Quantum Tensor Network ansatz whose tensors are laid out in a 1D chain.
+Due to this, these networks are also known as _Tensor Trains_ in other scientific fields.
+Depending on the boundary conditions, the chains can be open or closed (i.e. periodic boundary conditions), currently
+only `Open` boundary conditions are supported in `Tenet`.
 
 ```@setup viz
 using Makie
@@ -10,25 +11,108 @@ Makie.inline!(true)
 set_theme!(resolution=(800,200))
 
 using CairoMakie
-using GraphMakie
 
 using Tenet
 using NetworkLayout
 ```
 
 ```@example viz
-tn = rand(MPS; n=10, maxdim=4) # hide
-graphplot(tn, layout=Spring(iterations=1000, C=0.5, seed=100)) # hide
+fig = Figure()
+open_mps = rand(MPS; n=10, maxdim=4)
+
+plot!(fig[1,1], open_mps, layout=Spring(iterations=1000, C=0.5, seed=100))
+Label(fig[1,1, Bottom()], "Open")
+
+fig
 ```
+
+The default ordering of the indices on the `MPS` constructor is (physical, left, right), but you can specify the ordering by passing the `order` keyword argument:
+
+```@example
+mps = MPS([rand(4, 2), rand(4, 8, 2), rand(8, 2)]; order=[:l, :r, :o])
+```
+where `:l`, `:r`, and `:o` represent the left, right, and outer physical indices, respectively.
+
+
+### Canonical Forms
+
+An `MPS` representation is not unique: a single `MPS` can be represented in different canonical forms. The choice of canonical form can affect the efficiency and stability of algorithms used to manipulate the `MPS`.
+The current form of the `MPS` is stored as the trait [`Form`](@ref) and can be accessed via the `form` function:
+
+```@example
+mps = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
+
+form(mps)
+```
+> :warning: Depending on the form, `Tenet` will dispatch under the hood the appropriate algorithm which assumes full use of the canonical form, so be careful when making modifications that might alter the canonical form without changing the trait.
+
+`Tenet` has the internal function [`Tenet.check_form`](@ref) to check if the `MPS` is in the correct canonical form. This function can be used to ensure that the `MPS` is in the correct form before performing any operation that requires it.
+Currently, `Tenet` supports the [`NonCanonical`](@ref), [`CanonicalForm`](@ref) and [`MixedCanonical`](@ref) forms.
+
+#### `NonCanonical` Form
+In the `NonCanonical` form, the tensors in the `MPS` do not satisfy any particular orthogonality conditions. This is the default `form` when an `MPS` is initialized without specifying a canonical form. It is useful for general purposes but may not be optimal for certain computations that benefit from orthogonality.
+
+#### `Canonical` Form
+Also known as Vidal's form, the `Canonical` form represents the `MPS` using a sequence of isometric tensors (`Γ`) and diagonal vectors (`λ`) containing the Schmidt coefficients. The `MPS` is expressed as:
+
+```math
+| \psi \rangle = \sum_{i_1, \dots, i_N} \Gamma_1^{i_1} \lambda_2 \Gamma_2^{i_2} \dots \lambda_{N-1} \Gamma_{N-1}^{i_{N-1}} \lambda_N \Gamma_N^{i_N} | i_1, \dots, i_N \rangle \, .
+```
+
+You can convert an `MPS` to the `Canonical` form by calling `canonize!`:
+
+```@example
+mps = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
+canonize!(mps)
+
+form(mps)
+```
+
+#### `MixedCanonical` Form
+In the `MixedCanonical` form, tensors to the left of the orthogonality center are left-canonical, tensors to the right are right-canonical, and the tensors at the orthogonality center (which can be `Site` or `Vector{<:Site}`) contains the entanglement information between the left and right parts of the chain. The position of the orthogonality center is stored in the `orthog_center` field.
+
+You can convert an `MPS` to the `MixedCanonical` form and specify the orthogonality center using `mixed_canonize!`. Additionally, one can check that the `MPS` is effectively in mixed canonical form using the functions `isleftcanonical` and `isrightcanonical`, which return `true` if the `Tensor` at that particular site is left or right canonical, respectively.
+
+```@example
+mps = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
+mixed_canonize!(mps, Site(2))
+
+isisometry(mps, 1; dir=:right) # Check if the first tensor is left canonical
+isisometry(mps, 3; dir=:left) # Check if the third tensor is right canonical
+```
+
+form(mps)
+```
+
+##### Additional Resources
+For more in-depth information on Matrix Product States and their canonical forms, you may refer to:
+- Schollwöck, U. (2011). The density-matrix renormalization group in the age of matrix product states. Annals of physics, 326(1), 96-192.
+
 
 ## Matrix Product Operators (MPO)
 
-Matrix Product Operators (MPO) are the operator version of [Matrix Product State (MPS)](#matrix-product-states-mps).
-The major difference between them is that MPOs have 2 indices per site (1 input and 1 output) while MPSs only have 1 index per site (i.e. an output).
+Matrix Product Operators ([`MPO`](@ref)) are the operator version of [Matrix Product State (MPS)](#matrix-product-states-mps).
+The major difference between them is that MPOs have 2 indices per site (1 input and 1 output) while MPSs only have 1 index per site (i.e. an output). Currently, only `Open` boundary conditions are supported in `Tenet`.
 
 ```@example viz
-tn = rand(MPO; n=10, maxdim=4) # hide
-graphplot(tn, layout=Spring(iterations=1000, C=0.5, seed=100)) # hide
+fig = Figure()
+open_mpo = rand(MPO, n=10, maxdim=4)
+
+plot!(fig[1,1], open_mpo, layout=Spring(iterations=1000, C=0.5, seed=100))
+Label(fig[1,1, Bottom()], "Open")
+
+fig
 ```
 
-In `Tenet`, the generic `MatrixProduct` ansatz implements this topology. Type variables are used to address their functionality (`State` or `Operator`) and their boundary conditions (`Open` or `Periodic`).
+To apply an `MPO` to an `MPS`, you can use the `evolve!` function:
+
+```@example
+mps = rand(MPS; n=10, maxdim=100)
+mpo = rand(MPO; n=10, maxdim=4)
+
+size.(tensors(mps))
+
+evolve!(mps, mpo)
+
+size.(tensors(mps))
+```

--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -1,8 +1,8 @@
 # Matrix Product States (MPS)
 
-Matrix Product States ([`MPS`](@ref)) are a Quantum Tensor Network ansatz whose tensors are laid out in a 1D chain.
+Matrix Product States ([`MPS`](@ref)) are a Quantum Tensor Network [`Ansatz`](@ref) whose tensors are laid out in a 1D chain.
 Due to this, these networks are also known as _Tensor Trains_ in other scientific fields.
-Depending on the boundary conditions, the chains can be open or closed (i.e. periodic boundary conditions), currently
+Depending on the boundary conditions, these chains can be open or closed (i.e. periodic boundary conditions). Currently
 only `Open` boundary conditions are supported in `Tenet`.
 
 ```@setup viz
@@ -11,24 +11,25 @@ Makie.inline!(true)
 set_theme!(resolution=(800,200))
 
 using CairoMakie
+using GraphMakie
 
 using Tenet
 using NetworkLayout
 ```
 
 ```@example viz
-fig = Figure()
+fig = Figure() # hide
 open_mps = rand(MPS; n=10, maxdim=4)
 
-plot!(fig[1,1], open_mps, layout=Spring(iterations=1000, C=0.5, seed=100))
-Label(fig[1,1, Bottom()], "Open")
+plot!(fig[1,1], open_mps, layout=Spring(iterations=1000, C=0.5, seed=100)) # hide
+Label(fig[1,1, Bottom()], "Open") # hide
 
-fig
+fig # hide
 ```
 
 The default ordering of the indices on the `MPS` constructor is (physical, left, right), but you can specify the ordering by passing the `order` keyword argument:
 
-```@example
+```@repl
 mps = MPS([rand(4, 2), rand(4, 8, 2), rand(8, 2)]; order=[:l, :r, :o])
 ```
 where `:l`, `:r`, and `:o` represent the left, right, and outer physical indices, respectively.
@@ -39,7 +40,7 @@ where `:l`, `:r`, and `:o` represent the left, right, and outer physical indices
 An `MPS` representation is not unique: a single `MPS` can be represented in different canonical forms. The choice of canonical form can affect the efficiency and stability of algorithms used to manipulate the `MPS`.
 The current form of the `MPS` is stored as the trait [`Form`](@ref) and can be accessed via the `form` function:
 
-```@example
+```@repl
 mps = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
 
 form(mps)
@@ -61,7 +62,7 @@ Also known as Vidal's form, the `Canonical` form represents the `MPS` using a se
 
 You can convert an `MPS` to the `Canonical` form by calling `canonize!`:
 
-```@example
+```@repl
 mps = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
 canonize!(mps)
 
@@ -73,7 +74,7 @@ In the `MixedCanonical` form, tensors to the left of the orthogonality center ar
 
 You can convert an `MPS` to the `MixedCanonical` form and specify the orthogonality center using `mixed_canonize!`. Additionally, one can check that the `MPS` is effectively in mixed canonical form using the functions `isleftcanonical` and `isrightcanonical`, which return `true` if the `Tensor` at that particular site is left or right canonical, respectively.
 
-```@example
+```@repl
 mps = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
 mixed_canonize!(mps, Site(2))
 
@@ -95,18 +96,18 @@ Matrix Product Operators ([`MPO`](@ref)) are the operator version of [Matrix Pro
 The major difference between them is that MPOs have 2 indices per site (1 input and 1 output) while MPSs only have 1 index per site (i.e. an output). Currently, only `Open` boundary conditions are supported in `Tenet`.
 
 ```@example viz
-fig = Figure()
+fig = Figure() # hide
 open_mpo = rand(MPO, n=10, maxdim=4)
 
-plot!(fig[1,1], open_mpo, layout=Spring(iterations=1000, C=0.5, seed=100))
-Label(fig[1,1, Bottom()], "Open")
+plot!(fig[1,1], open_mpo, layout=Spring(iterations=1000, C=0.5, seed=100)) # hide
+Label(fig[1,1, Bottom()], "Open") # hide
 
-fig
+fig # hide
 ```
 
 To apply an `MPO` to an `MPS`, you can use the `evolve!` function:
 
-```@example
+```@repl
 mps = rand(MPS; n=10, maxdim=100)
 mpo = rand(MPO; n=10, maxdim=4)
 

--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -82,7 +82,6 @@ mixed_canonize!(mps, Site(2))
 
 isisometry(mps, 1; dir=:right) # Check if the first tensor is left canonical
 isisometry(mps, 3; dir=:left) # Check if the third tensor is right canonical
-```
 
 form(mps)
 ```

--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -5,7 +5,7 @@ Due to this, these networks are also known as _Tensor Trains_ in other scientifi
 Depending on the boundary conditions, these chains can be open or closed (i.e. periodic boundary conditions). Currently
 only `Open` boundary conditions are supported in `Tenet`.
 
-```@setup viz
+```@setup plot
 using Tenet
 using Makie
 Makie.inline!(true)
@@ -19,7 +19,7 @@ using Tenet
 using NetworkLayout
 ```
 
-```@example viz
+```@example plot
 fig = Figure() # hide
 open_mps = rand(MPS; n=10, maxdim=4)
 
@@ -97,7 +97,7 @@ For more in-depth information on Matrix Product States and their canonical forms
 Matrix Product Operators ([`MPO`](@ref)) are the operator version of [Matrix Product State (MPS)](#matrix-product-states-mps).
 The major difference between them is that MPOs have 2 indices per site (1 input and 1 output) while MPSs only have 1 index per site (i.e. an output). Currently, only `Open` boundary conditions are supported in `Tenet`.
 
-```@example viz
+```@example plot
 fig = Figure() # hide
 open_mpo = rand(MPO, n=10, maxdim=4)
 

--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -109,7 +109,7 @@ fig # hide
 To apply an [`MPO`](@ref) to an [`MPS`](@ref), you can use the [`evolve!`](@ref) function:
 
 ```@repl examples
-mps = rand(MPS; n=6)
+mps = rand(MPS; n=10)
 
 evolve!(mps, open_mpo; normalize=false)
 ```

--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -28,13 +28,13 @@ fig # hide
 
 In Tenet, a Matrix Product State can be easily created by passing a list of arrays to the [`MPS`](@ref) constructor:
 ```@repl examples
-mps = MPS([rand(2, 2), rand(2, 4, 2), rand(4, 2, 2) rand(2, 2)])
+mps = MPS([rand(2, 2), rand(2, 4, 2), rand(4, 2, 2), rand(2, 2)])
 ```
 
 The default ordering of the indices on the [`MPS`](@ref) constructor is (physical, left, right), but you can specify the ordering by passing the `order` keyword argument:
 
 ```@repl examples
-mps = MPS([rand(2, 2), rand(2, 2, 4), rand(2, 4, 2) rand(2, 2)]; order=[:o, :l, :r])
+mps = MPS([rand(2, 2), rand(2, 2, 4), rand(2, 4, 2), rand(2, 2)]; order=[:o, :l, :r])
 ```
 where `:l`, `:r`, and `:o` represent the left, right, and outer physical indices, respectively.
 

--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -108,12 +108,14 @@ fig # hide
 To apply an `MPO` to an `MPS`, you can use the `evolve!` function:
 
 ```@repl plot
-mps = rand(MPS; n=10, maxdim=100)
-mpo = rand(MPO; n=10, maxdim=4)
+mps = rand(MPS; n=6)
+mpo = rand(MPO; n=6)
 
 size.(tensors(mps))
 
-evolve!(mps, mpo)
+evolve!(mps, mpo; normalize=false)
 
 size.(tensors(mps))
 ```
+
+As we can see, the bond dimension of the `MPS` has increased after applying the `MPO` to it.

--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -4,9 +4,9 @@
 using Tenet
 using Makie
 Makie.inline!(true)
-set_theme!(resolution=(800,200))
-using CairoMakie
+set_theme!(resolution=(800,400))
 using GraphMakie
+using CairoMakie
 CairoMakie.activate!(type = "svg")
 using NetworkLayout
 ```
@@ -28,13 +28,13 @@ fig # hide
 
 In Tenet, a Matrix Product State can be easily created by passing a list of arrays to the [`MPS`](@ref) constructor:
 ```@repl examples
-mps = MPS([rand(2, 2), rand(2, 4, 2), rand(4, 2, 2), rand(2, 2)])
+mps = MPS([rand(2, 2), rand(2, 2, 4), rand(2, 4, 2), rand(2, 2)])
 ```
 
 The default ordering of the indices on the [`MPS`](@ref) constructor is (physical, left, right), but you can specify the ordering by passing the `order` keyword argument:
 
 ```@repl examples
-mps = MPS([rand(2, 2), rand(2, 2, 4), rand(2, 4, 2), rand(2, 2)]; order=[:o, :l, :r])
+mps = MPS([rand(2, 2), rand(2, 2, 4), rand(4, 2, 2), rand(2, 2)]; order=[:l, :o, :r])
 ```
 where `:l`, `:r`, and `:o` represent the left, right, and outer physical indices, respectively.
 

--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -6,12 +6,14 @@ Depending on the boundary conditions, these chains can be open or closed (i.e. p
 only `Open` boundary conditions are supported in `Tenet`.
 
 ```@setup viz
+using Tenet
 using Makie
 Makie.inline!(true)
 set_theme!(resolution=(800,200))
 
 using CairoMakie
 using GraphMakie
+CairoMakie.activate!(type = "svg")
 
 using Tenet
 using NetworkLayout
@@ -29,7 +31,7 @@ fig # hide
 
 The default ordering of the indices on the `MPS` constructor is (physical, left, right), but you can specify the ordering by passing the `order` keyword argument:
 
-```@repl
+```@repl plot
 mps = MPS([rand(4, 2), rand(4, 8, 2), rand(8, 2)]; order=[:l, :r, :o])
 ```
 where `:l`, `:r`, and `:o` represent the left, right, and outer physical indices, respectively.
@@ -40,7 +42,7 @@ where `:l`, `:r`, and `:o` represent the left, right, and outer physical indices
 An `MPS` representation is not unique: a single `MPS` can be represented in different canonical forms. The choice of canonical form can affect the efficiency and stability of algorithms used to manipulate the `MPS`.
 The current form of the `MPS` is stored as the trait [`Form`](@ref) and can be accessed via the `form` function:
 
-```@repl
+```@repl plot
 mps = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
 
 form(mps)
@@ -62,7 +64,7 @@ Also known as Vidal's form, the `Canonical` form represents the `MPS` using a se
 
 You can convert an `MPS` to the `Canonical` form by calling `canonize!`:
 
-```@repl
+```@repl plot
 mps = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
 canonize!(mps)
 
@@ -74,7 +76,7 @@ In the `MixedCanonical` form, tensors to the left of the orthogonality center ar
 
 You can convert an `MPS` to the `MixedCanonical` form and specify the orthogonality center using `mixed_canonize!`. Additionally, one can check that the `MPS` is effectively in mixed canonical form using the functions `isleftcanonical` and `isrightcanonical`, which return `true` if the `Tensor` at that particular site is left or right canonical, respectively.
 
-```@repl
+```@repl plot
 mps = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
 mixed_canonize!(mps, Site(2))
 
@@ -107,7 +109,7 @@ fig # hide
 
 To apply an `MPO` to an `MPS`, you can use the `evolve!` function:
 
-```@repl
+```@repl plot
 mps = rand(MPS; n=10, maxdim=100)
 mpo = rand(MPO; n=10, maxdim=4)
 

--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -11,9 +11,7 @@ CairoMakie.activate!(type = "svg")
 using NetworkLayout
 ```
 
-Matrix Product States ([`MPS`](@ref)) are a Quantum Tensor Network [`Ansatz`](@ref) whose tensors are laid out in a 1D chain.
-Due to this, these networks are also known as _Tensor Trains_ in other scientific fields.
-Depending on the boundary conditions, these chains can be open or closed (i.e. periodic boundary conditions).
+Matrix Product States ([`MPS`](@ref)) (also known as _Tensor Trains_) are a Quantum Tensor Network [`Ansatz`](@ref) whose tensors are laid out in a 1D chain. Depending on the boundary conditions, these chains can be open or closed (i.e. periodic boundary conditions).
 
 !!! warning
     Currently only [`Open`](@ref) boundary conditions are supported in Tenet.

--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -1,10 +1,5 @@
 # Matrix Product States (MPS)
 
-Matrix Product States ([`MPS`](@ref)) are a Quantum Tensor Network [`Ansatz`](@ref) whose tensors are laid out in a 1D chain.
-Due to this, these networks are also known as _Tensor Trains_ in other scientific fields.
-Depending on the boundary conditions, these chains can be open or closed (i.e. periodic boundary conditions). Currently
-only `Open` boundary conditions are supported in `Tenet`.
-
 ```@setup plot
 using Tenet
 using Makie
@@ -15,9 +10,13 @@ using CairoMakie
 using GraphMakie
 CairoMakie.activate!(type = "svg")
 
-using Tenet
 using NetworkLayout
 ```
+
+Matrix Product States ([`MPS`](@ref)) are a Quantum Tensor Network [`Ansatz`](@ref) whose tensors are laid out in a 1D chain.
+Due to this, these networks are also known as _Tensor Trains_ in other scientific fields.
+Depending on the boundary conditions, these chains can be open or closed (i.e. periodic boundary conditions). Currently
+only `Open` boundary conditions are supported in `Tenet`.
 
 ```@example plot
 fig = Figure() # hide

--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -11,7 +11,7 @@ CairoMakie.activate!(type = "svg")
 using NetworkLayout
 ```
 
-Matrix Product States ([`MPS`](@ref)) (also known as _Tensor Trains_) are a Quantum Tensor Network [`Ansatz`](@ref) whose tensors are laid out in a 1D chain. Depending on the boundary conditions, these chains can be open or closed (i.e. periodic boundary conditions).
+Matrix Product States ([`MPS`](@ref)) (also known as _Tensor Trains_) are [`Ansatz`](@ref) Tensor Networks whose tensors are laid out in a 1D chain. Depending on the boundary conditions, these chains can be open or closed (i.e. periodic boundary conditions).
 
 !!! warning
     Currently only [`Open`](@ref) boundary conditions are supported in Tenet.
@@ -55,20 +55,20 @@ form(ψ)
 !!! warning
     Depending on the form, Tenet will dispatch under the hood the appropriate algorithm which assumes full use of the canonical form, so be careful when making modifications that might alter the canonical form without changing the trait.
 
-Tenet has the internal function [`Tenet.check_form`](@ref) to check if the `MPS` is in the correct canonical form. This function can be used to ensure that the `MPS` is in the correct form before performing any operation that requires it.
+Tenet has the internal function [`Tenet.check_form`](@ref) to check if the [`MPS`](@ref) is in the correct canonical form. This function can be used to ensure that the [`MPS`](@ref) is in the correct form before performing any operation that requires it.
 Currently, Tenet supports the [`NonCanonical`](@ref), [`CanonicalForm`](@ref) and [`MixedCanonical`](@ref) forms.
 
 #### `NonCanonical` Form
 In the [`NonCanonical`](@ref) form, the tensors in the [`MPS`](@ref) do not satisfy any particular orthogonality conditions. This is the default [`form`](@ref) when an [`MPS`](@ref) is initialized without specifying a canonical form. It is useful for general purposes but may not be optimal for certain computations that benefit from orthogonality.
 
 #### `Canonical` Form
-Also known as Vidal's form, the [`Canonical`](@ref) form represents the [`MPS`](@ref) using a sequence of tensors (`Γ`) and diagonal vectors (`λ`) containing the Schmidt coefficients. The [`MPS`](@ref) is expressed as:
+Also known as Vidal's form, the [`Canonical`](@ref) form represents the [`MPS`](@ref) using a sequence of tensors $\Gamma$ and diagonal vectors $\Lambda$ containing the Schmidt coefficients. The [`MPS`](@ref) is expressed as:
 
 ```math
-| \psi \rangle = \sum_{i_1, \dots, i_N} \Gamma_1^{i_1} \lambda_2 \Gamma_2^{i_2} \dots \lambda_{N-1} \Gamma_{N-1}^{i_{N-1}} \lambda_N \Gamma_N^{i_N} | i_1, \dots, i_N \rangle \, .
+| \psi \rangle = \sum_{i_1, \dots, i_N} \Gamma_1^{i_1} \Lambda_2 \Gamma_2^{i_2} \dots \Lambda_{N-1} \Gamma_{N-1}^{i_{N-1}} \Lambda_N \Gamma_N^{i_N} | i_1, \dots, i_N \rangle \, .
 ```
 
-You can convert an `MPS` to the `Canonical` form by calling `canonize!`:
+You can convert an [`MPS`](@ref) to the [`Canonical`](@ref) form by calling [`canonize!`](@ref):
 
 ```@repl examples
 canonize!(ψ)
@@ -77,9 +77,12 @@ form(ψ)
 ```
 
 #### `MixedCanonical` Form
-In the [`MixedCanonical`](@ref) form, tensors to the left of the orthogonality center are left-canonical, tensors to the right are right-canonical, and the tensors at the orthogonality center (which can be [`Site`](@ref) or `Vector{<:Site}`) contains the entanglement information between the left and right parts of the chain. In Tenet, a left (right) canonical `Tensor` is an isometry pointing to the direction right (left). The position of the orthogonality center is stored in the `orthog_center` field.
+In the [`MixedCanonical`](@ref) form, the Schmidt coefficients are contained in one tensor, called the orthogonality center, and the rest of the tensors locating to the left and right side are left- and right-canonical; i.e. isometries pointing to the right and left directions respectively.
 
-You can convert an [`MPS`](@ref) to the [`MixedCanonical`](@ref) form and specify the orthogonality center using [`mixed_canonize!`](@ref). Additionally, one can check that the `MPS` is effectively in mixed canonical form using the function [`isisometry`](@ref), which returns `True` if the [`Tensor`](@ref) at that particular site is an isometry pointing at direction `dir`:
+!!! tip
+    If the Schmidt coefficients are spread out along multiple tensors but localized, then [`MixedCanonical`](@ref) accepts using a `Vector{<:Site}` for representing the orthogonality center.
+
+You can convert an [`MPS`](@ref) to the [`MixedCanonical`](@ref) form and specify the orthogonality center using [`mixed_canonize!`](@ref). Additionally, one can check that the [`MPS`](@ref) is effectively in mixed canonical form using the function [`isisometry`](@ref), which returns `true` if the [`Tensor`](@ref) at that particular site is an isometry pointing at direction `dir`:
 
 ```@repl examples
 mixed_canonize!(ψ, Site(2))
@@ -92,8 +95,11 @@ form(ψ)
 
 ## Matrix Product Operators (MPO)
 
-Matrix Product Operators ([`MPO`](@ref)) are the operator version of [Matrix Product State (MPS)](#matrix-product-states-mps).
-The major difference between them is that MPOs have 2 indices per site (1 input and 1 output) while MPSs only have 1 index per site (i.e. an output). Currently, only [`Open`](@ref) boundary conditions are supported in Tenet.
+Matrix Product Operators ([`MPO`](@ref)) are the operator version of [Matrix Product States (MPS)](@ref).
+The major difference between them is that MPOs have 2 indices per site (1 input and 1 output) while MPSs only have 1 index per site (i.e. an output).
+
+!!! warning
+    Currently, only [`Open`](@ref) boundary conditions are supported for [`MPO`](@ref).
 
 ```@example examples
 fig = Figure() # hide

--- a/docs/src/manual/ansatz/mps.md
+++ b/docs/src/manual/ansatz/mps.md
@@ -42,7 +42,6 @@ Additionally, Tenet has the [`rand`](@ref) function to generate random [`MPS`](@
 
 ```@repl examples
 Φ = rand(MPS, n=8, maxdim=10)
-size.(tensors(Φ))
 ```
 
 ### Canonical Forms


### PR DESCRIPTION
### Summary
This PR continues with the development started in PR #262, which is a bit behind the chain of commits so we are redoing the PR.

This PR updates the `MPS` manual, accounting with the changes from `MPS` refactor (PR #232) and thus adding explanation of the different canonical forms we support. I think it makes sense that the manual for the canonical forms is in this `MPS` manual. 

### TO DO:
- [x] Convert examples to REPL.
- [x] Change text so it matches the style from the other tutorials.