### PR TITLE
Fix tensor-number multiplication

### DIFF
--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -141,8 +141,8 @@ end
 Alias for [`contract`](@ref).
 """
 Base.:*(a::Tensor, b::Tensor) = contract(a, b)
-Base.:*(a::Tensor, b::Number) = T(parent(a) * b, inds(a))
-Base.:*(a::Number, b::Tensor) = T(a * parent(b), inds(b))
+Base.:*(a::Tensor, b::Number) = Tensor(parent(a) * b, inds(a))
+Base.:*(a::Number, b::Tensor) = Tensor(a * parent(b), inds(b))
 
 function factorinds(tensor, left_inds, right_inds)
     isdisjoint(left_inds, right_inds) ||

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -16,16 +16,6 @@
         @test parent(D) ≈ parent(A) - permutedims(parent(B), (3, 1, 4, 2))
     end
 
-    @testset "tensor-number multiplication" begin
-        data = rand(2, 3, 4)
-        realnum = 2
-        complexnum = 2 + 2im
-
-        A = Tensor(data, (:i, :j, :k))
-        @test data * realnum ≈ parent(A * realnum) ≈ parent(realnum * A)
-        @test data * complexnum ≈ parent(A * complexnum) ≈ parent(complexnum * A)
-    end
-
     @testset "contract" begin
         @testset "axis sum" begin
             A = Tensor(rand(2, 3, 4), (:i, :j, :k))
@@ -55,6 +45,16 @@
             @test inds(C) == (:j,)
             @test size(C) == size(C_ein) == (3,)
             @test parent(C) ≈ C_ein
+        end
+
+        @testset "* alias" begin
+            data = rand(2, 3, 4)
+            realnum = 2
+            complexnum = 2 + 2im
+    
+            A = Tensor(data, (:i, :j, :k))
+            @test data * realnum ≈ parent(A * realnum) ≈ parent(realnum * A)
+            @test data * complexnum ≈ parent(A * complexnum) ≈ parent(complexnum * A)
         end
 
         @testset "matrix multiplication" begin

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -51,7 +51,7 @@
             data = rand(2, 3, 4)
             realnum = 2
             complexnum = 2 + 2im
-    
+
             A = Tensor(data, (:i, :j, :k))
             @test data * realnum ≈ parent(A * realnum) ≈ parent(realnum * A)
             @test data * complexnum ≈ parent(A * complexnum) ≈ parent(complexnum * A)

--- a/test/Numerics_test.jl
+++ b/test/Numerics_test.jl
@@ -16,6 +16,16 @@
         @test parent(D) ≈ parent(A) - permutedims(parent(B), (3, 1, 4, 2))
     end
 
+    @testset "tensor-number multiplication" begin
+        data = rand(2, 3, 4)
+        realnum = 2
+        complexnum = 2 + 2im
+
+        A = Tensor(data, (:i, :j, :k))
+        @test data * realnum ≈ parent(A * realnum) ≈ parent(realnum * A)
+        @test data * complexnum ≈ parent(A * complexnum) ≈ parent(complexnum * A)
+    end
+
     @testset "contract" begin
         @testset "axis sum" begin
             A = Tensor(rand(2, 3, 4), (:i, :j, :k))


### PR DESCRIPTION
This PR resolves a bug where the type `T` does NOT exist but it should be type `Tensor` in multiplication operation.