### PR TITLE
Fix sites in Yao to Tenet conversion

### DIFF
--- a/ext/TenetYaoBlocksExt.jl
+++ b/ext/TenetYaoBlocksExt.jl
@@ -22,7 +22,7 @@ function Base.convert(::Type{Circuit}, yaocirc::AbstractBlock)
         # end
 
         gatelanes = Lane.(occupied_locs(gate))
-        gatesites = [Site.(gatelanes; dual=true)..., Site.(gatelanes)...]
+        gatesites = [Site.(gatelanes)..., Site.(gatelanes; dual=true)...]
 
         # NOTE `YaoBlocks.mat` on m-site qubits still returns the operator on the full Hilbert space
         m = length(occupied_locs(gate))

--- a/test/integration/YaoBlocks_test.jl
+++ b/test/integration/YaoBlocks_test.jl
@@ -11,33 +11,31 @@ using YaoBlocks
     end
 
     @testset "GHZ" begin
-        n = 3
-        yaocirc = chain(n, put(1 => Yao.H), Yao.control(1, 2 => Yao.X), Yao.control(2, 3 => Yao.X))
+        n_qubits = 3
+        yaocirc = chain(n_qubits, put(1 => H), Yao.control(1, 2 => X), Yao.control(2, 3 => X))
         circuit = convert(Circuit, yaocirc)
 
-        # <111|circuit|000>
-        zeros = Quantum(Product(fill([1, 0], n))) #|000>
-        ones = Quantum(Product(fill([0, 1], n))) #|111>
-        ampl111 = only(Tenet.contract(merge(zeros, Quantum(circuit), ones')))
+        zerost = Quantum(Product(fill([1, 0], n_qubits))) #|000>
+        onest = Quantum(Product(fill([0, 1], n_qubits))) #|111>
 
-        yaoampl111 = apply!(zero_state(n), yaocirc)[bit"111"]
+        expected_value = Tenet.contract(merge(zerost, Quantum(circuit), onest')) # Tenet <111|circuit|000>
 
-        @test yaoampl111 ≈ ampl111 ≈ 1 / √2
+        yaosv = apply!(zero_state(n_qubits), yaocirc) # circuit|000>
+        @test only(expected_value) ≈ only(statevec(ArrayReg(bit"111"))' * statevec(yaosv)) ≈ 1 / √2 # Yao <111|circuit|000>
     end
 
     @testset "two-qubit dense gate" begin
-        n = 2
+        n_qubits = 2
         U = matblock(rand(ComplexF64, 4, 4); tag="U")
-        yaocirc = chain(2, put((1, 2) => U))
-
-        # <11|circuit|00>
+        yaocirc = chain(n_qubits, put((1, 2) => U))
         circuit = convert(Circuit, yaocirc)
-        zeros = Quantum(Product(fill([1, 0], 2))) #|00>
-        ones = Quantum(Product(fill([0, 1], 2))) #|11>
-        ampl11 = Tenet.contract(merge(zeros, Quantum(circuit), ones'))
+        
+        zerost = Quantum(Product(fill([1, 0], n_qubits))) #|00>
+        onest = Quantum(Product(fill([0, 1], n_qubits))) #|11>
 
-        yaoampl11 = apply!(zero_state(n), yaocirc)[bit"11"]
+        expected_value = Tenet.contract(merge(zerost, Quantum(circuit), onest')) # Tenet <11|circuit|00>
 
-        @test only(ampl11) ≈ yaoampl11
+        yaosv = apply!(zero_state(n_qubits), yaocirc) # circuit|00>
+        @test only(expected_value) ≈ only(statevec(ArrayReg(bit"11"))' * statevec(yaosv)) # Yao <11|circuit|00>
     end
 end

--- a/test/integration/YaoBlocks_test.jl
+++ b/test/integration/YaoBlocks_test.jl
@@ -29,7 +29,7 @@ using YaoBlocks
         U = matblock(rand(ComplexF64, 4, 4); tag="U")
         yaocirc = chain(n_qubits, put((1, 2) => U))
         circuit = convert(Circuit, yaocirc)
-        
+
         zerost = Quantum(Product(fill([1, 0], n_qubits))) #|00>
         onest = Quantum(Product(fill([0, 1], n_qubits))) #|11>
 


### PR DESCRIPTION
When converting a `Yao` circuit to a `Tenet` tensor network, the gates' sites and its duals had an incorrect order causing a bad interconnection inside the tensor network. This is, the outputs were taken as inputs and viceversa giving the following inconsistent results:
```julia
julia> U.mat
4×4 Matrix{ComplexF64}:
 0.512459+0.606575im   0.88142+0.973414im  0.617066+0.694744im    0.765335+0.470115im
 0.196287+0.34693im   0.618943+0.114418im  0.905947+0.0761331im   0.237069+0.318266im
 0.586231+0.158916im  0.189495+0.691832im  0.991734+0.241937im    0.675667+0.365597im
 0.303253+0.705869im  0.575559+0.778916im  0.511385+0.380175im   0.0958053+0.303978im

julia> Tenet.contract(merge(zerost, Quantum(circuit), onest')) # Tenet <11|U|00>
0-dimensional Tensor{ComplexF64, 0, Array{ComplexF64, 0}}:
0.7653346690086762 + 0.4701150758843342im

julia> onesv' * U.mat * zerosv # Yao <11|U|00>
0.3032530724516256 + 0.7058692432387914im
```