### PR TITLE
Add basic benchmarking workflow, create benchmark/ folder with bench script

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -1,0 +1,66 @@
+name: Tenet benchmarks with BenchmarkTools.jl
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  deployments: write
+
+jobs:
+  benchmark:
+    name: Run tenet benchmark
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v4
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: runner.os−test−env.cache−name−{{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            runner.os−test−
+            ${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - name: Run benchmark
+        run: |
+          cd benchmarks
+          julia --project --color=yes -e '
+            using Pkg;
+            #Pkg.Registry.add(url = "https://github.com/bsc-quantic/Registry");
+            pkg"registry add https://github.com/bsc-quantic/Registry.git";
+            pkg"registry add General";
+            Pkg.instantiate();
+            pkg"add Tenet#master";
+            include("bench1.jl")'
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: tenet benchmark result
+          tool: 'julia'
+          output-file-path: benchmarks/output.json
+          # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t/github-action-not-triggering-gh-pages-upon-push/16096
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Show alert with commit comment on detecting possible performance regression
+          #alert-threshold: '200%'
+          #comment-on-alert: true
+          #fail-on-alert: true
+          #alert-comment-cc-users: '@ktrz,@findmyway'

--- a/benchmarks/bench1.jl
+++ b/benchmarks/bench1.jl
@@ -1,0 +1,33 @@
+using BenchmarkTools
+
+using Tenet
+
+function overlap_tenet(L)
+
+    psi = rand(MPS, n=L, maxdim=30)
+    phi = rand(MPS, n=L, maxdim=50)
+    o = rand(MPO, n=L, maxdim=1)
+
+    #psic = copy(psi)
+    evolve!(psi, o)
+
+    return overlap(psi,phi)
+end
+
+bench_1 = "<phi|O|psi>"
+bench_sub1 = "L=10"
+bench_sub2 = "L=20"
+
+suite = BenchmarkGroup()
+
+suite[bench_1] = BenchmarkGroup(["overlaps"])
+
+suite[bench_1][bench_sub1]["x"]["Tenet"] = @benchmarkable overlap_tenet(10)
+suite[bench_1][bench_sub2]["x"]["Tenet"] = @benchmarkable overlap_tenet(20)
+
+tune!(suite)
+results1 = run(suite, verbose = true)
+
+r1 = median(results1)
+
+BenchmarkTools.save("output.json", r1)


### PR DESCRIPTION
Ideally this should create some benchmark data in `dev/bench/data.js`  in the `gh-pages` branch, as well as an accompanying index.html  - I have an updated index.html as well but I don't know how to make it such that the pr puts it in the gh-pages folder... 

