### PR TITLE
Update calls to deprecated methods

### DIFF
--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -526,8 +526,8 @@ function simple_update_2site!(::Canonical, ψ::AbstractAnsatz, gate; threshold, 
     Λᵢ₋₁ = id(lanel) == 1 ? nothing : tensors(ψ; bond=(Lane(id(lanel) - 1), lanel))
     Λᵢ₊₁ = id(lanel) == nsites(ψ) - 1 ? nothing : tensors(ψ; bond=(laner, Lane(id(laner) + 1)))
 
-    !isnothing(Λᵢ₋₁) && contract!(ψ; bond=(Lane(id(lanel) - 1), lanel), dir=:right, delete_Λ=false)
-    !isnothing(Λᵢ₊₁) && contract!(ψ; bond=(laner, Lane(id(laner) + 1)), dir=:left, delete_Λ=false)
+    !isnothing(Λᵢ₋₁) && absorb!(ψ; bond=(Lane(id(lanel) - 1), lanel), dir=:right, delete_Λ=false)
+    !isnothing(Λᵢ₊₁) && absorb!(ψ; bond=(laner, Lane(id(laner) + 1)), dir=:left, delete_Λ=false)
 
     simple_update_2site!(NonCanonical(), ψ, gate; threshold, maxdim, normalize=false, canonize=false)
 

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -526,8 +526,8 @@ function simple_update_2site!(::Canonical, ψ::AbstractAnsatz, gate; threshold, 
     Λᵢ₋₁ = id(lanel) == 1 ? nothing : tensors(ψ; bond=(Lane(id(lanel) - 1), lanel))
     Λᵢ₊₁ = id(lanel) == nsites(ψ) - 1 ? nothing : tensors(ψ; bond=(laner, Lane(id(laner) + 1)))
 
-    !isnothing(Λᵢ₋₁) && contract!(ψ; bond=(Lane(id(lanel) - 1), lanel), direction=:right, delete_Λ=false)
-    !isnothing(Λᵢ₊₁) && contract!(ψ; bond=(laner, Lane(id(laner) + 1)), direction=:left, delete_Λ=false)
+    !isnothing(Λᵢ₋₁) && contract!(ψ; bond=(Lane(id(lanel) - 1), lanel), dir=:right, delete_Λ=false)
+    !isnothing(Λᵢ₊₁) && contract!(ψ; bond=(laner, Lane(id(laner) + 1)), dir=:left, delete_Λ=false)
 
     simple_update_2site!(NonCanonical(), ψ, gate; threshold, maxdim, normalize=false, canonize=false)
 

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -523,11 +523,11 @@ function simple_update_2site!(::Canonical, ψ::AbstractAnsatz, gate; threshold, 
     (0 < id(lanel) < nlanes(ψ) || 0 < id(laner) < nlanes(ψ)) ||
         throw(ArgumentError("The sites in the bond must be between 1 and $(nlanes(ψ))"))
 
-    Λᵢ₋₁ = id(lanel) == 1 ? nothing : tensors(ψ; between=(Lane(id(lanel) - 1), lanel))
-    Λᵢ₊₁ = id(lanel) == nsites(ψ) - 1 ? nothing : tensors(ψ; between=(laner, Lane(id(laner) + 1)))
+    Λᵢ₋₁ = id(lanel) == 1 ? nothing : tensors(ψ; bond=(Lane(id(lanel) - 1), lanel))
+    Λᵢ₊₁ = id(lanel) == nsites(ψ) - 1 ? nothing : tensors(ψ; bond=(laner, Lane(id(laner) + 1)))
 
-    !isnothing(Λᵢ₋₁) && contract!(ψ; between=(Lane(id(lanel) - 1), lanel), direction=:right, delete_Λ=false)
-    !isnothing(Λᵢ₊₁) && contract!(ψ; between=(laner, Lane(id(laner) + 1)), direction=:left, delete_Λ=false)
+    !isnothing(Λᵢ₋₁) && contract!(ψ; bond=(Lane(id(lanel) - 1), lanel), direction=:right, delete_Λ=false)
+    !isnothing(Λᵢ₊₁) && contract!(ψ; bond=(laner, Lane(id(laner) + 1)), direction=:left, delete_Λ=false)
 
     simple_update_2site!(NonCanonical(), ψ, gate; threshold, maxdim, normalize=false, canonize=false)
 

--- a/src/MPS.jl
+++ b/src/MPS.jl
@@ -152,12 +152,12 @@ end
 
 function check_form(::Canonical, mps::AbstractMPO; atol=1e-12)
     for i in 1:nlanes(mps)
-        if i > 1 && !isisometry(contract(mps; bond=(Lane(i - 1), Lane(i)), direction=:right), Lane(i); dir=:right, atol)
+        if i > 1 && !isisometry(contract(mps; bond=(Lane(i - 1), Lane(i)), dir=:right), Lane(i); dir=:right, atol)
             throw(ArgumentError("Can not form a left-canonical tensor in Lane($i) from Γ and λ contraction."))
         end
 
         if i < nlanes(mps) &&
-            !isisometry(contract(mps; bond=(Lane(i), Lane(i + 1)), direction=:left), Lane(i); dir=:left, atol)
+            !isisometry(contract(mps; bond=(Lane(i), Lane(i + 1)), dir=:left), Lane(i); dir=:left, atol)
             throw(ArgumentError("Can not form a right-canonical tensor in Site($i) from Γ and λ contraction."))
         end
     end
@@ -454,8 +454,8 @@ function isisometry(ψ::AbstractMPO, site; dir, atol::Real=1e-12)
     return isapprox(contracted, I(n); atol)
 end
 
-@deprecate isleftcanonical(ψ::AbstractMPO, site; atol::Real=1e-12) isisometry(ψ, site; dir=:right, atol)
-@deprecate isrightcanonical(ψ::AbstractMPO, site; atol::Real=1e-12) isisometry(ψ, site; dir=:left, atol)
+@deprecate isleftcanonical(ψ::AbstractMPO, lane; atol::Real=1e-12) isisometry(ψ, lane; dir=:right, atol)
+@deprecate isrightcanonical(ψ::AbstractMPO, lane; atol::Real=1e-12) isisometry(ψ, lane; dir=:left, atol)
 
 # TODO generalize to AbstractAnsatz
 # NOTE: in method == :svd the spectral weights are stored in a vector connected to the now virtual hyperindex!

--- a/src/Tenet.jl
+++ b/src/Tenet.jl
@@ -70,7 +70,7 @@ include("Product.jl")
 export Product
 
 include("MPS.jl")
-export MPS, MPO
+export MPS, MPO, absorb, absorb!
 @compat public AbstractMPS, AbstractMPO, defaultorder, check_form
 
 # reexports from EinExprs

--- a/test/unit/MPO_test.jl
+++ b/test/unit/MPO_test.jl
@@ -100,10 +100,10 @@ end
             @test isisometry(canonized, Lane(i); dir=:right)
         elseif i == 5 # in the limits of the chain, we get the norm of the state
             normalize!(tensors(canonized; bond=(Lane(i - 1), Lane(i))))
-            contract!(canonized; bond=(Lane(i - 1), Lane(i)), dir=:right)
+            absorb!(canonized; bond=(Lane(i - 1), Lane(i)), dir=:right)
             @test isisometry(canonized, Lane(i); dir=:right)
         else
-            contract!(canonized; bond=(Lane(i - 1), Lane(i)), dir=:right)
+            absorb!(canonized; bond=(Lane(i - 1), Lane(i)), dir=:right)
             @test isisometry(canonized, Lane(i); dir=:right)
         end
     end
@@ -113,12 +113,12 @@ end
 
         if i == 1 # in the limits of the chain, we get the norm of the state
             normalize!(tensors(canonized; bond=(Lane(i), Lane(i + 1))))
-            contract!(canonized; bond=(Lane(i), Lane(i + 1)), dir=:left)
+            absorb!(canonized; bond=(Lane(i), Lane(i + 1)), dir=:left)
             @test isisometry(canonized, Lane(i); dir=:left)
         elseif i == 5
             @test isisometry(canonized, Lane(i); dir=:left)
         else
-            contract!(canonized; bond=(Lane(i), Lane(i + 1)), dir=:left)
+            absorb!(canonized; bond=(Lane(i), Lane(i + 1)), dir=:left)
             @test isisometry(canonized, Lane(i); dir=:left)
         end
     end

--- a/test/unit/MPO_test.jl
+++ b/test/unit/MPO_test.jl
@@ -1,3 +1,5 @@
+using Test
+using Tenet
 
 H = MPO([rand(2, 2, 4), rand(2, 2, 4, 4), rand(2, 2, 4)])
 @test socket(H) == Operator()
@@ -76,8 +78,6 @@ end
 end
 
 @testset "canonize!" begin
-    using Tenet: isleftcanonical, isrightcanonical
-
     ψ = MPO([rand(4, 4, 4), rand(4, 4, 4, 4), rand(4, 4, 4, 4), rand(4, 4, 4, 4), rand(4, 4, 4)])
     canonized = canonize(ψ)
 
@@ -97,14 +97,14 @@ end
         canonized = canonize(ψ)
 
         if i == 1
-            @test isleftcanonical(canonized, Lane(i))
+            @test isisometry(canonized, Lane(i); dir=:right)
         elseif i == 5 # in the limits of the chain, we get the norm of the state
             normalize!(tensors(canonized; bond=(Lane(i - 1), Lane(i))))
             contract!(canonized; bond=(Lane(i - 1), Lane(i)), direction=:right)
-            @test isleftcanonical(canonized, Lane(i))
+            @test isisometry(canonized, Lane(i); dir=:right)
         else
             contract!(canonized; bond=(Lane(i - 1), Lane(i)), direction=:right)
-            @test isleftcanonical(canonized, Lane(i))
+            @test isisometry(canonized, Lane(i); dir=:right)
         end
     end
 
@@ -114,12 +114,12 @@ end
         if i == 1 # in the limits of the chain, we get the norm of the state
             normalize!(tensors(canonized; bond=(Lane(i), Lane(i + 1))))
             contract!(canonized; bond=(Lane(i), Lane(i + 1)), direction=:left)
-            @test isrightcanonical(canonized, Lane(i))
+            @test isisometry(canonized, Lane(i); dir=:left)
         elseif i == 5
-            @test isrightcanonical(canonized, Lane(i))
+            @test isisometry(canonized, Lane(i); dir=:left)
         else
             contract!(canonized; bond=(Lane(i), Lane(i + 1)), direction=:left)
-            @test isrightcanonical(canonized, Lane(i))
+            @test isisometry(canonized, Lane(i); dir=:left)
         end
     end
 end

--- a/test/unit/MPO_test.jl
+++ b/test/unit/MPO_test.jl
@@ -100,10 +100,10 @@ end
             @test isisometry(canonized, Lane(i); dir=:right)
         elseif i == 5 # in the limits of the chain, we get the norm of the state
             normalize!(tensors(canonized; bond=(Lane(i - 1), Lane(i))))
-            contract!(canonized; bond=(Lane(i - 1), Lane(i)), direction=:right)
+            contract!(canonized; bond=(Lane(i - 1), Lane(i)), dir=:right)
             @test isisometry(canonized, Lane(i); dir=:right)
         else
-            contract!(canonized; bond=(Lane(i - 1), Lane(i)), direction=:right)
+            contract!(canonized; bond=(Lane(i - 1), Lane(i)), dir=:right)
             @test isisometry(canonized, Lane(i); dir=:right)
         end
     end
@@ -113,12 +113,12 @@ end
 
         if i == 1 # in the limits of the chain, we get the norm of the state
             normalize!(tensors(canonized; bond=(Lane(i), Lane(i + 1))))
-            contract!(canonized; bond=(Lane(i), Lane(i + 1)), direction=:left)
+            contract!(canonized; bond=(Lane(i), Lane(i + 1)), dir=:left)
             @test isisometry(canonized, Lane(i); dir=:left)
         elseif i == 5
             @test isisometry(canonized, Lane(i); dir=:left)
         else
-            contract!(canonized; bond=(Lane(i), Lane(i + 1)), direction=:left)
+            contract!(canonized; bond=(Lane(i), Lane(i + 1)), dir=:left)
             @test isisometry(canonized, Lane(i); dir=:left)
         end
     end

--- a/test/unit/MPO_test.jl
+++ b/test/unit/MPO_test.jl
@@ -88,7 +88,7 @@ end
     @test isapprox(norm(ψ), norm(canonized))
 
     # Extract the singular values between each adjacent pair of sites in the canonized chain
-    Λ = [tensors(canonized; between=(Lane(i), Lane(i + 1))) for i in 1:4]
+    Λ = [tensors(canonized; bond=(Lane(i), Lane(i + 1))) for i in 1:4]
 
     norm_psi = norm(ψ)
     @test all(λ -> sqrt(sum(abs2, λ)) ≈ norm_psi, Λ)
@@ -100,10 +100,10 @@ end
             @test isleftcanonical(canonized, Lane(i))
         elseif i == 5 # in the limits of the chain, we get the norm of the state
             normalize!(tensors(canonized; bond=(Lane(i - 1), Lane(i))))
-            contract!(canonized; between=(Lane(i - 1), Lane(i)), direction=:right)
+            contract!(canonized; bond=(Lane(i - 1), Lane(i)), direction=:right)
             @test isleftcanonical(canonized, Lane(i))
         else
-            contract!(canonized; between=(Lane(i - 1), Lane(i)), direction=:right)
+            contract!(canonized; bond=(Lane(i - 1), Lane(i)), direction=:right)
             @test isleftcanonical(canonized, Lane(i))
         end
     end
@@ -113,12 +113,12 @@ end
 
         if i == 1 # in the limits of the chain, we get the norm of the state
             normalize!(tensors(canonized; bond=(Lane(i), Lane(i + 1))))
-            contract!(canonized; between=(Lane(i), Lane(i + 1)), direction=:left)
+            contract!(canonized; bond=(Lane(i), Lane(i + 1)), direction=:left)
             @test isrightcanonical(canonized, Lane(i))
         elseif i == 5
             @test isrightcanonical(canonized, Lane(i))
         else
-            contract!(canonized; between=(Lane(i), Lane(i + 1)), direction=:left)
+            contract!(canonized; bond=(Lane(i), Lane(i + 1)), direction=:left)
             @test isrightcanonical(canonized, Lane(i))
         end
     end

--- a/test/unit/MPS_test.jl
+++ b/test/unit/MPS_test.jl
@@ -130,7 +130,7 @@ end
 @testset "truncate!" begin
     @testset "NonCanonical" begin
         ψ = MPS([rand(2, 2), rand(2, 2, 2), rand(2, 2)])
-        canonize_site!(ψ, lane"2"; direction=:right, method=:svd)
+        canonize_site!(ψ, lane"2"; dir=:right, method=:svd)
 
         truncated = truncate(ψ, [lane"2", lane"3"]; maxdim=1)
         @test size(truncated, inds(truncated; bond=[lane"2", lane"3"])) == 1
@@ -230,29 +230,29 @@ end
 @testset "canonize_site!" begin
     ψ = MPS([rand(4, 4), rand(4, 4, 4), rand(4, 4)])
 
-    @test_throws ArgumentError canonize_site!(ψ, lane"1"; direction=:left)
-    @test_throws ArgumentError canonize_site!(ψ, lane"3"; direction=:right)
+    @test_throws ArgumentError canonize_site!(ψ, lane"1"; dir=:left)
+    @test_throws ArgumentError canonize_site!(ψ, lane"3"; dir=:right)
 
     for method in [:qr, :svd]
-        canonized = canonize_site(ψ, lane"1"; direction=:right, method=method)
+        canonized = canonize_site(ψ, lane"1"; dir=:right, method=method)
         @test isisometry(canonized, lane"1"; dir=:right)
         @test isapprox(contract(transform(TensorNetwork(canonized), Tenet.HyperFlatten())), contract(ψ))
 
-        canonized = canonize_site(ψ, lane"2"; direction=:right, method=method)
+        canonized = canonize_site(ψ, lane"2"; dir=:right, method=method)
         @test isisometry(canonized, lane"2"; dir=:right)
         @test isapprox(contract(transform(TensorNetwork(canonized), Tenet.HyperFlatten())), contract(ψ))
 
-        canonized = canonize_site(ψ, lane"2"; direction=:left, method=method)
+        canonized = canonize_site(ψ, lane"2"; dir=:left, method=method)
         @test isisometry(canonized, lane"2"; dir=:left)
         @test isapprox(contract(transform(TensorNetwork(canonized), Tenet.HyperFlatten())), contract(ψ))
 
-        canonized = canonize_site(ψ, lane"3"; direction=:left, method=method)
+        canonized = canonize_site(ψ, lane"3"; dir=:left, method=method)
         @test isisometry(canonized, lane"3"; dir=:left)
         @test isapprox(contract(transform(TensorNetwork(canonized), Tenet.HyperFlatten())), contract(ψ))
     end
 
     # Ensure that svd creates a new tensor
-    @test length(tensors(canonize_site(ψ, lane"2"; direction=:left, method=:svd))) == 4
+    @test length(tensors(canonize_site(ψ, lane"2"; dir=:left, method=:svd))) == 4
 end
 
 @testset "canonize!" begin
@@ -278,10 +278,10 @@ end
             @test isisometry(canonized, Lane(i); dir=:right)
         elseif i == 5 # in the limits of the chain, we get the norm of the state
             normalize!(tensors(canonized; bond=(Lane(i - 1), Lane(i))))
-            contract!(canonized; bond=(Lane(i - 1), Lane(i)), direction=:right)
+            contract!(canonized; bond=(Lane(i - 1), Lane(i)), dir=:right)
             @test isisometry(canonized, Lane(i); dir=:right)
         else
-            contract!(canonized; bond=(Lane(i - 1), Lane(i)), direction=:right)
+            contract!(canonized; bond=(Lane(i - 1), Lane(i)), dir=:right)
             @test isisometry(canonized, Lane(i); dir=:right)
         end
     end
@@ -291,12 +291,12 @@ end
 
         if i == 1 # in the limits of the chain, we get the norm of the state
             normalize!(tensors(canonized; bond=(Lane(i), Lane(i + 1))))
-            contract!(canonized; bond=(Lane(i), Lane(i + 1)), direction=:left)
+            contract!(canonized; bond=(Lane(i), Lane(i + 1)), dir=:left)
             @test isisometry(canonized, Lane(i); dir=:left)
         elseif i == 5
             @test isisometry(canonized, Lane(i); dir=:left)
         else
-            contract!(canonized; bond=(Lane(i), Lane(i + 1)), direction=:left)
+            contract!(canonized; bond=(Lane(i), Lane(i + 1)), dir=:left)
             @test isisometry(canonized, Lane(i); dir=:left)
         end
     end
@@ -468,7 +468,7 @@ end
 @testset "contract bond" begin
     ψ = rand(MPS; n=5, maxdim=20)
     let canonized = canonize(ψ)
-        @test_throws ArgumentError contract!(canonized; bond=(lane"1", lane"2"), direction=:dummy)
+        @test_throws ArgumentError contract!(canonized; bond=(lane"1", lane"2"), dir=:dummy)
     end
 
     canonized = canonize(ψ)

--- a/test/unit/MPS_test.jl
+++ b/test/unit/MPS_test.jl
@@ -235,19 +235,19 @@ end
 
     for method in [:qr, :svd]
         canonized = canonize_site(ψ, lane"1"; direction=:right, method=method)
-        @test isleftcanonical(canonized, lane"1")
+        @test isisometry(canonized, lane"1"; dir=:right)
         @test isapprox(contract(transform(TensorNetwork(canonized), Tenet.HyperFlatten())), contract(ψ))
 
         canonized = canonize_site(ψ, lane"2"; direction=:right, method=method)
-        @test isleftcanonical(canonized, lane"2")
+        @test isisometry(canonized, lane"2"; dir=:right)
         @test isapprox(contract(transform(TensorNetwork(canonized), Tenet.HyperFlatten())), contract(ψ))
 
         canonized = canonize_site(ψ, lane"2"; direction=:left, method=method)
-        @test isrightcanonical(canonized, lane"2")
+        @test isisometry(canonized, lane"2"; dir=:left)
         @test isapprox(contract(transform(TensorNetwork(canonized), Tenet.HyperFlatten())), contract(ψ))
 
         canonized = canonize_site(ψ, lane"3"; direction=:left, method=method)
-        @test isrightcanonical(canonized, lane"3")
+        @test isisometry(canonized, lane"3"; dir=:left)
         @test isapprox(contract(transform(TensorNetwork(canonized), Tenet.HyperFlatten())), contract(ψ))
     end
 
@@ -256,8 +256,6 @@ end
 end
 
 @testset "canonize!" begin
-    using Tenet: isleftcanonical, isrightcanonical
-
     ψ = MPS([rand(4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4, 4), rand(4, 4)])
     canonized = canonize(ψ)
 
@@ -277,14 +275,14 @@ end
         canonized = canonize(ψ)
 
         if i == 1
-            @test isleftcanonical(canonized, Lane(i))
+            @test isisometry(canonized, Lane(i); dir=:right)
         elseif i == 5 # in the limits of the chain, we get the norm of the state
             normalize!(tensors(canonized; bond=(Lane(i - 1), Lane(i))))
             contract!(canonized; bond=(Lane(i - 1), Lane(i)), direction=:right)
-            @test isleftcanonical(canonized, Lane(i))
+            @test isisometry(canonized, Lane(i); dir=:right)
         else
             contract!(canonized; bond=(Lane(i - 1), Lane(i)), direction=:right)
-            @test isleftcanonical(canonized, Lane(i))
+            @test isisometry(canonized, Lane(i); dir=:right)
         end
     end
 
@@ -294,12 +292,12 @@ end
         if i == 1 # in the limits of the chain, we get the norm of the state
             normalize!(tensors(canonized; bond=(Lane(i), Lane(i + 1))))
             contract!(canonized; bond=(Lane(i), Lane(i + 1)), direction=:left)
-            @test isrightcanonical(canonized, Lane(i))
+            @test isisometry(canonized, Lane(i); dir=:left)
         elseif i == 5
-            @test isrightcanonical(canonized, Lane(i))
+            @test isisometry(canonized, Lane(i); dir=:left)
         else
             contract!(canonized; bond=(Lane(i), Lane(i + 1)), direction=:left)
-            @test isrightcanonical(canonized, Lane(i))
+            @test isisometry(canonized, Lane(i); dir=:left)
         end
     end
 end
@@ -482,8 +480,8 @@ end
         @test isapprox(contract(contract_some), contract(ψ))
         @test_throws Tenet.MissingSchmidtCoefficientsException tensors(contract_some; bond=(Lane(i), Lane(i + 1)))
 
-        @test isrightcanonical(contract_some, Lane(i))
-        @test isleftcanonical(contract(canonized; bond=(Lane(i), Lane(i + 1)), direction=:right), Lane(i + 1))
+        @test isisometry(contract_some, Lane(i); dir=:left)
+        @test isisometry(contract(canonized; bond=(Lane(i), Lane(i + 1)), dir=:right), Lane(i + 1); dir=:right)
 
         Γᵢ = tensors(canonized; at=Lane(i))
         Λᵢ₊₁ = tensors(canonized; bond=(Lane(i), Lane(i + 1)))

--- a/test/unit/MPS_test.jl
+++ b/test/unit/MPS_test.jl
@@ -278,10 +278,10 @@ end
             @test isisometry(canonized, Lane(i); dir=:right)
         elseif i == 5 # in the limits of the chain, we get the norm of the state
             normalize!(tensors(canonized; bond=(Lane(i - 1), Lane(i))))
-            contract!(canonized; bond=(Lane(i - 1), Lane(i)), dir=:right)
+            absorb!(canonized; bond=(Lane(i - 1), Lane(i)), dir=:right)
             @test isisometry(canonized, Lane(i); dir=:right)
         else
-            contract!(canonized; bond=(Lane(i - 1), Lane(i)), dir=:right)
+            absorb!(canonized; bond=(Lane(i - 1), Lane(i)), dir=:right)
             @test isisometry(canonized, Lane(i); dir=:right)
         end
     end
@@ -291,12 +291,12 @@ end
 
         if i == 1 # in the limits of the chain, we get the norm of the state
             normalize!(tensors(canonized; bond=(Lane(i), Lane(i + 1))))
-            contract!(canonized; bond=(Lane(i), Lane(i + 1)), dir=:left)
+            absorb!(canonized; bond=(Lane(i), Lane(i + 1)), dir=:left)
             @test isisometry(canonized, Lane(i); dir=:left)
         elseif i == 5
             @test isisometry(canonized, Lane(i); dir=:left)
         else
-            contract!(canonized; bond=(Lane(i), Lane(i + 1)), dir=:left)
+            absorb!(canonized; bond=(Lane(i), Lane(i + 1)), dir=:left)
             @test isisometry(canonized, Lane(i); dir=:left)
         end
     end
@@ -468,20 +468,20 @@ end
 @testset "contract bond" begin
     ψ = rand(MPS; n=5, maxdim=20)
     let canonized = canonize(ψ)
-        @test_throws ArgumentError contract!(canonized; bond=(lane"1", lane"2"), dir=:dummy)
+        @test_throws ArgumentError absorb!(canonized; bond=(lane"1", lane"2"), dir=:dummy)
     end
 
     canonized = canonize(ψ)
 
     for i in 1:4
-        contract_some = contract(canonized; bond=(Lane(i), Lane(i + 1)))
+        contract_some = absorb(canonized; bond=(Lane(i), Lane(i + 1)))
         Bᵢ = tensors(contract_some; at=Lane(i))
 
         @test isapprox(contract(contract_some), contract(ψ))
         @test_throws Tenet.MissingSchmidtCoefficientsException tensors(contract_some; bond=(Lane(i), Lane(i + 1)))
 
         @test isisometry(contract_some, Lane(i); dir=:left)
-        @test isisometry(contract(canonized; bond=(Lane(i), Lane(i + 1)), dir=:right), Lane(i + 1); dir=:right)
+        @test isisometry(absorb(canonized; bond=(Lane(i), Lane(i + 1)), dir=:right), Lane(i + 1); dir=:right)
 
         Γᵢ = tensors(canonized; at=Lane(i))
         Λᵢ₊₁ = tensors(canonized; bond=(Lane(i), Lane(i + 1)))

--- a/test/unit/MPS_test.jl
+++ b/test/unit/MPS_test.jl
@@ -135,7 +135,7 @@ end
         truncated = truncate(ψ, [lane"2", lane"3"]; maxdim=1)
         @test size(truncated, inds(truncated; bond=[lane"2", lane"3"])) == 1
 
-        singular_values = tensors(ψ; between=(lane"2", lane"3"))
+        singular_values = tensors(ψ; bond=(lane"2", lane"3"))
         truncated = truncate(ψ, [lane"2", lane"3"]; threshold=singular_values[2] + 0.1)
         @test size(truncated, inds(truncated; bond=[lane"2", lane"3"])) == 1
 
@@ -268,7 +268,7 @@ end
     @test isapprox(norm(ψ), norm(canonized))
 
     # Extract the singular values between each adjacent pair of sites in the canonized chain
-    Λ = [tensors(canonized; between=(Lane(i), Lane(i + 1))) for i in 1:4]
+    Λ = [tensors(canonized; bond=(Lane(i), Lane(i + 1))) for i in 1:4]
 
     norm_psi = norm(ψ)
     @test all(λ -> sqrt(sum(abs2, λ)) ≈ norm_psi, Λ)
@@ -280,10 +280,10 @@ end
             @test isleftcanonical(canonized, Lane(i))
         elseif i == 5 # in the limits of the chain, we get the norm of the state
             normalize!(tensors(canonized; bond=(Lane(i - 1), Lane(i))))
-            contract!(canonized; between=(Lane(i - 1), Lane(i)), direction=:right)
+            contract!(canonized; bond=(Lane(i - 1), Lane(i)), direction=:right)
             @test isleftcanonical(canonized, Lane(i))
         else
-            contract!(canonized; between=(Lane(i - 1), Lane(i)), direction=:right)
+            contract!(canonized; bond=(Lane(i - 1), Lane(i)), direction=:right)
             @test isleftcanonical(canonized, Lane(i))
         end
     end
@@ -293,12 +293,12 @@ end
 
         if i == 1 # in the limits of the chain, we get the norm of the state
             normalize!(tensors(canonized; bond=(Lane(i), Lane(i + 1))))
-            contract!(canonized; between=(Lane(i), Lane(i + 1)), direction=:left)
+            contract!(canonized; bond=(Lane(i), Lane(i + 1)), direction=:left)
             @test isrightcanonical(canonized, Lane(i))
         elseif i == 5
             @test isrightcanonical(canonized, Lane(i))
         else
-            contract!(canonized; between=(Lane(i), Lane(i + 1)), direction=:left)
+            contract!(canonized; bond=(Lane(i), Lane(i + 1)), direction=:left)
             @test isrightcanonical(canonized, Lane(i))
         end
     end
@@ -467,26 +467,26 @@ end
 end
 
 # TODO rename when method is renamed
-@testset "contract between" begin
+@testset "contract bond" begin
     ψ = rand(MPS; n=5, maxdim=20)
     let canonized = canonize(ψ)
-        @test_throws ArgumentError contract!(canonized; between=(lane"1", lane"2"), direction=:dummy)
+        @test_throws ArgumentError contract!(canonized; bond=(lane"1", lane"2"), direction=:dummy)
     end
 
     canonized = canonize(ψ)
 
     for i in 1:4
-        contract_some = contract(canonized; between=(Lane(i), Lane(i + 1)))
+        contract_some = contract(canonized; bond=(Lane(i), Lane(i + 1)))
         Bᵢ = tensors(contract_some; at=Lane(i))
 
         @test isapprox(contract(contract_some), contract(ψ))
-        @test_throws Tenet.MissingSchmidtCoefficientsException tensors(contract_some; between=(Lane(i), Lane(i + 1)))
+        @test_throws Tenet.MissingSchmidtCoefficientsException tensors(contract_some; bond=(Lane(i), Lane(i + 1)))
 
         @test isrightcanonical(contract_some, Lane(i))
-        @test isleftcanonical(contract(canonized; between=(Lane(i), Lane(i + 1)), direction=:right), Lane(i + 1))
+        @test isleftcanonical(contract(canonized; bond=(Lane(i), Lane(i + 1)), direction=:right), Lane(i + 1))
 
         Γᵢ = tensors(canonized; at=Lane(i))
-        Λᵢ₊₁ = tensors(canonized; between=(Lane(i), Lane(i + 1)))
+        Λᵢ₊₁ = tensors(canonized; bond=(Lane(i), Lane(i + 1)))
         @test Bᵢ ≈ contract(Γᵢ, Λᵢ₊₁; dims=())
     end
 end


### PR DESCRIPTION
Deprecation warnings remain. This PR just fixes calls to deprecated methods on internal code and tests.

@jofrevalles I've renamed `contract!` on `MPS` for contracting the $\Lambda$ to a tensor to `absorb!` because (1) it was conflicting with `contract!(; bond)` and the dispatch wasn't working, and (2) I think semantically this is more representative. wdyt?