### PR TITLE
Add check in `replace!` to ensure old `Tensor` is in the `TensorNetwork`

### DIFF
--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -507,7 +507,7 @@ function Base.replace!(tn::AbstractTensorNetwork, pair::Pair{<:Tensor,<:Tensor})
     tn = TensorNetwork(tn)
     old_tensor, new_tensor = pair
 
-    old_tensor ∈ collect(keys(tn.tensormap)) || throw(ArgumentError("Old tensor not found in TensorNetwork"))
+    old_tensor ∈ tn || throw(ArgumentError("Old tensor not found in TensorNetwork"))
 
     old_tensor === new_tensor && return tn
 

--- a/src/TensorNetwork.jl
+++ b/src/TensorNetwork.jl
@@ -507,6 +507,8 @@ function Base.replace!(tn::AbstractTensorNetwork, pair::Pair{<:Tensor,<:Tensor})
     tn = TensorNetwork(tn)
     old_tensor, new_tensor = pair
 
+    old_tensor ∈ collect(keys(tn.tensormap)) || throw(ArgumentError("Old tensor not found in TensorNetwork"))
+
     old_tensor === new_tensor && return tn
 
     issetequal(inds(new_tensor), inds(old_tensor)) || throw(ArgumentError("replacing tensor indices don't match"))

--- a/test/unit/TensorNetwork_test.jl
+++ b/test/unit/TensorNetwork_test.jl
@@ -484,6 +484,9 @@ end
 
             old_tensor = t_lm
 
+            # Test that it throws an error if the old tensor is not in the tensor network
+            @test_throws ArgumentError replace!(tn, Tensor(ones(2, 2), (:i, :j)) => t_ij)
+
             @test_throws ArgumentError begin
                 new_tensor = Tensor(rand(2, 2), (:a, :b))
                 replace!(tn, old_tensor => new_tensor)


### PR DESCRIPTION
### Summary
This PR resolves #330 by adding a line in `replace!` function that checks if the old `Tensor` is in the `TensorNetwork`, and `throws` an `ArgumentError` if it is not.

Additionally, we also added a test to cover for this issue.

### Example
```julia
julia> using Tenet

julia> mps = rand(MPS; n=6)
MPS (inputs=0, outputs=6)

julia> A = tensors(mps, at=Site(2))
2×2×4 Tensor{Float64, 3, Array{Float64, 3}}: ...

julia> B = Tensor(rand(size(A)...), inds(A)) # New Tensor, same inds as A but different data
2×2×4 Tensor{Float64, 3, Array{Float64, 3}}: ...

julia> C = Tensor(rand(size(A)...), inds(A)) # New Tensor, same inds as A but different data
2×2×4 Tensor{Float64, 3, Array{Float64, 3}}: ...

julia> replace!(mps, B => C) # Now we get an error :)
ERROR: ArgumentError: Old tensor not found in TensorNetwork
Stacktrace:
 [1] replace!(tn::MPS, pair::Pair{Tensor{Float64, 3, Array{Float64, 3}}, Tensor{Float64, 3, Array{Float64, 3}}})
   @ Tenet ~/git/Tenet.jl/src/TensorNetwork.jl:510
 [2] top-level scope
   @ REPL[48]:1

julia> inds(mps, set=:open)
6-element Vector{Symbol}:
 :F
 :D
 :B
 :E
 :A
 :C
```