### PR TITLE
Extend `expect` function to account on `form`

### DIFF
--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -165,7 +165,6 @@ function inds(kwargs::NamedTuple{(:bond,)}, tn::AbstractAnsatz)
     return only(inds(tensor1) ∩ inds(tensor2))
 end
 
-# TODO fix this properly when we do the mapping
 function tensors(kwargs::NamedTuple{(:at,),Tuple{L}}, tn::AbstractAnsatz) where {L<:Lane}
     hassite(tn, Site(kwargs.at)) && return tensors(tn; at=Site(kwargs.at))
     hassite(tn, Site(kwargs.at; dual=true)) && return tensors(tn; at=Site(kwargs.at; dual=true))

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -407,24 +407,28 @@ function expect(::Canonical, ψ::Tenet.AbstractAnsatz, observable; bra=adjoint(�
     bra_tensors = []
     for i in obs_sites
         replace!(observable, inds(observable; at=Site(i)) => Symbol(:input, i))
-        replace!(observable, inds(observable; at=Site(i, dual=true)) => Symbol(:output, i))
-        replace!(ψ, inds(ψ, at=Site(i)) => Symbol(:input, i))
-        replace!(bra, inds(bra, at=Site(i, dual=true)) => Symbol(:output, i))
+        replace!(observable, inds(observable; at=Site(i; dual=true)) => Symbol(:output, i))
+        replace!(ψ, inds(ψ; at=Site(i)) => Symbol(:input, i))
+        replace!(bra, inds(bra; at=Site(i; dual=true)) => Symbol(:output, i))
 
-        replace!(bra, inds(bra, bond=(Lane(i), Lane(i+1))) => inds(ψ, bond=(Lane(i), Lane(i+1))))
-        replace!(bra, inds(bra, bond=(Lane(i-1), Lane(i))) => inds(ψ, bond=(Lane(i-1), Lane(i))))
+        replace!(bra, inds(bra; bond=(Lane(i), Lane(i + 1))) => inds(ψ; bond=(Lane(i), Lane(i + 1))))
+        replace!(bra, inds(bra; bond=(Lane(i - 1), Lane(i))) => inds(ψ; bond=(Lane(i - 1), Lane(i))))
 
-        push!(ket_Λ, tensors(ψ, bond=(Lane(i-1), Lane(i))))
-        push!(bra_Λ, tensors(bra, bond=(Lane(i-1), Lane(i))))
+        push!(ket_Λ, tensors(ψ; bond=(Lane(i - 1), Lane(i))))
+        push!(bra_Λ, tensors(bra; bond=(Lane(i - 1), Lane(i))))
 
-        push!(ket_tensors, tensors(ψ, at=Site(i)))
-        push!(bra_tensors, tensors(bra, at=Site(i, dual=true)))
+        push!(ket_tensors, tensors(ψ; at=Site(i)))
+        push!(bra_tensors, tensors(bra; at=Site(i; dual=true)))
     end
 
-    push!(ket_Λ, tensors(ψ, bond=(Lane(obs_sites[end]), Lane(obs_sites[end]+1))))
-    push!(bra_Λ, tensors(bra, bond=(Lane(obs_sites[end]), Lane(obs_sites[end]+1))))
+    push!(ket_Λ, tensors(ψ; bond=(Lane(obs_sites[end]), Lane(obs_sites[end] + 1))))
+    push!(bra_Λ, tensors(bra; bond=(Lane(obs_sites[end]), Lane(obs_sites[end] + 1))))
 
-    t = contract(contract(ket_Λ..., ket_tensors...; dims=[]), contract(bra_Λ..., bra_tensors...; dims=[]), tensors(Quantum(observable))[1])
+    t = contract(
+        contract(ket_Λ..., ket_tensors...; dims=[]),
+        contract(bra_Λ..., bra_tensors...; dims=[]),
+        tensors(Quantum(observable))[1],
+    )
 
     return t
 end

--- a/src/Ansatz.jl
+++ b/src/Ansatz.jl
@@ -165,6 +165,7 @@ function inds(kwargs::NamedTuple{(:bond,)}, tn::AbstractAnsatz)
     return only(inds(tensor1) ∩ inds(tensor2))
 end
 
+# TODO fix this properly when we do the mapping
 function tensors(kwargs::NamedTuple{(:at,),Tuple{L}}, tn::AbstractAnsatz) where {L<:Lane}
     hassite(tn, Site(kwargs.at)) && return tensors(tn; at=Site(kwargs.at))
     hassite(tn, Site(kwargs.at; dual=true)) && return tensors(tn; at=Site(kwargs.at; dual=true))


### PR DESCRIPTION
### Summary
In this PR we extend the `expect` function to account on `Canonical` form, so now we only contract local tensors instead of the full `MPS`. We left the old implementation for `NonCanonical` and `MixedCanonical` forms, and we put a "TODO" comment on the latter to extend it in the future.

### Speed-up demonstration
You can see how we now get a much better performance from both `runtime` and `memory`:
```julia
julia> using Tenet

julia> using BenchmarkTools

julia> Z = [1 0; 0 -1]
2×2 Matrix{Int64}:
 1   0
 0  -1

julia> observable = Gate(Tensor(Z, (:i, :iᶜ)), [Site(5), Site(5, dual=true)])
Gate([1 0; 0 -1], Site[5, 5'])

julia> mps = rand(MPS; n=12); canonize!(mps)
MPS (inputs=0, outputs=12)

julia> @benchmark expect(mps, Quantum(observable)) # NEW implementation
BenchmarkTools.Trial: 4242 samples with 1 evaluation per sample.
 Range (min … max):  857.471 μs …  10.636 ms  ┊ GC (min … max): 0.00% … 86.25%
 Time  (median):       1.086 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):     1.176 ms ± 717.302 μs  ┊ GC (mean ± σ):  6.88% ±  9.55%

  ▃▇█▆▃▁                                                        ▁
  ██████▄▇▆▅▅▄▁▁▁▁▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▅▆▆ █
  857 μs        Histogram: log(frequency) by time       6.72 ms <

 Memory estimate: 1.06 MiB, allocs estimate: 26295.

julia> mps.form = NonCanonical()
NonCanonical()

julia> @benchmark expect(mps, Quantum(observable)) # OLD implementation
BenchmarkTools.Trial: 469 samples with 1 evaluation per sample.
 Range (min … max):   8.874 ms … 21.458 ms  ┊ GC (min … max): 0.00% … 41.72%
 Time  (median):      9.872 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   10.659 ms ±  2.205 ms  ┊ GC (mean ± σ):  7.17% ± 12.12%

   ▂▇▆▁▇█▇▁▁                                                   
  ▅█████████▇▅▄▄▃▃▃▁▂▃▁▁▂▁▃▂▂▁▁▁▁▁▁▁▁▁▂▃▂▃▃▂▃▃▃▄▃▄▃▃▂▂▃▂▁▁▁▂▂ ▃
  8.87 ms         Histogram: frequency by time        17.6 ms <

 Memory estimate: 10.68 MiB, allocs estimate: 240784.
```