### PR TITLE
Getsetindex mps

### DIFF
--- a/src/Components/MPS.jl
+++ b/src/Components/MPS.jl
@@ -133,3 +133,13 @@ Base.getindex(x::AbstractMPS, i::Site) = tensor_at(x, CartesianSite(i))
 
 Base.length(x::AbstractMPS) = ntensors(x)
 
+function Base.setindex!(x::AbstractMPS, tt::Tensor, i::Integer) 
+  @argcheck i > 0 
+  @argcheck i < length(x) + 2
+
+  if i <= length(x) 
+    replace_tensor!(x, x[i], tt)
+  else
+    addtensor!(x, tt)
+  end
+end

--- a/src/Components/MPS.jl
+++ b/src/Components/MPS.jl
@@ -126,3 +126,10 @@ function Base.rand(rng::Random.AbstractRNG, ::Type{MPS}; n, maxdim=nothing, elty
 
     return MPS(arrays; order=(:l, :o, :r))
 end
+
+
+Base.getindex(x::AbstractMPS, i::Integer) = tensor_at(x, CartesianSite(i))
+Base.getindex(x::AbstractMPS, i::Site) = tensor_at(x, CartesianSite(i))
+
+Base.length(x::AbstractMPS) = ntensors(x)
+


### PR DESCRIPTION
related issue #356

for getindex and length it looks pretty straightforward

for setindex there's the usual freedom to break stuff: do we want to put restrictions or let it open for all unsafe play  ? ie. replacing a tensor with a tensor with a different number of indices, with different sizes, with different indices, etc... 

In its current form it allows in principle also to append a tensor to the end, but of course there also one should correct the second-last tensor to get the additional bond, so it's not so trivial . open to feedback 

