### PR TITLE
change default maxdim for rand(MPS) to 128

### DIFF
--- a/src/Components/MPS.jl
+++ b/src/Components/MPS.jl
@@ -104,7 +104,7 @@ center at the first site). In order to avoid norm explosion issues, the tensors 
   - `eltype` The element type of the tensors. Defaults to `Float64`.
   - `physdim` The physical or output dimension of each site. Defaults to 2.
 """
-function Base.rand(rng::Random.AbstractRNG, ::Type{MPS}; n, maxdim=nothing, eltype=Float64, physdim=2)
+function Base.rand(rng::Random.AbstractRNG, ::Type{MPS}; n, maxdim=128, eltype=Float64, physdim=2)
     p = physdim
     T = eltype
     χ = isnothing(maxdim) ? Base.Checked.checked_pow(p, n ÷ 2) : maxdim


### PR DESCRIPTION
this avoids very unpleasant suprises when you are just trying to quickly rand(MPS, n=30) or so